### PR TITLE
feat: add haplotype.py shared utilities module

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -26,7 +26,7 @@ jobs:
           cache-suffix: ${{ matrix.PYTHON_VERSION }}
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
         with:
           distribution: temurin
           java-version: '11'

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -25,6 +25,12 @@ jobs:
           enable-cache: 'true'
           cache-suffix: ${{ matrix.PYTHON_VERSION }}
 
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'
+
       - name: Test the library
         run: |
           uv run --directory divref --locked poe check-all

--- a/divref/divref/haplotype.py
+++ b/divref/divref/haplotype.py
@@ -1,19 +1,24 @@
 """Shared utilities for Hail-based DivRef pipeline tools."""
 
 from typing import Any
+from typing import Hashable
+from typing import TypeVar
 
 import hail as hl
 
 HailPath = str
 """Type alias for filesystem paths accepted by Hail: local, GCS (gs://), or HDFS (hdfs://)."""
 
+_V = TypeVar("_V", bound=Hashable)
+"""Type variable for hashable dictionary values used in to_hashable_items."""
 
-def to_hashable_items(d: dict[str, Any]) -> tuple[tuple[str, Any], ...]:
+
+def to_hashable_items(d: dict[str, _V]) -> tuple[tuple[str, _V], ...]:
     """
     Convert a dictionary to a sorted tuple of items for use as a hashable key.
 
     Args:
-        d: Dictionary to convert.
+        d: Dictionary with hashable values to convert.
 
     Returns:
         Sorted tuple of (key, value) pairs.
@@ -32,10 +37,18 @@ def get_haplo_sequence(context_size: int, variants: Any) -> Any:
     Args:
         context_size: Number of reference bases to include flanking each end.
         variants: Hail array expression of variant structs with locus and alleles fields.
+            Must contain at least one variant.
 
     Returns:
         Hail string expression representing the full haplotype sequence.
+
+    Raises:
+        ValueError: If variants is a Python sequence with no elements.
     """
+    if isinstance(variants, (list, tuple)) and len(variants) == 0:
+        raise ValueError(
+            "get_haplo_sequence requires at least one variant; received an empty sequence"
+        )
     sorted_variants = hl.sorted(variants, key=lambda x: x.locus.position)
     min_variant = sorted_variants[0]
     max_variant = sorted_variants[-1]
@@ -89,9 +102,9 @@ def variant_distance(v1: Any, v2: Any) -> Any:
 
 def split_haplotypes(ht: Any, window_size: int) -> Any:
     """
-    Split multi-variant haplotypes at gaps larger than window_size bases.
+    Split multi-variant haplotypes at gaps of at least `window_size` bases.
 
-    Haplotypes spanning variants further than window_size bases apart are broken
+    Haplotypes spanning variants further than or equal to `window_size` bases apart are broken
     into sub-haplotypes at those gaps. Sub-haplotypes with fewer than two variants
     are discarded.
 

--- a/divref/divref/haplotype.py
+++ b/divref/divref/haplotype.py
@@ -1,0 +1,125 @@
+"""Shared utilities for Hail-based DivRef pipeline tools."""
+
+from typing import Any
+
+import hail as hl
+
+HailPath = str
+"""Type alias for filesystem paths accepted by Hail: local, GCS (gs://), or HDFS (hdfs://)."""
+
+
+def to_hashable_items(d: dict[str, Any]) -> tuple[tuple[str, Any], ...]:
+    """
+    Convert a dictionary to a sorted tuple of items for use as a hashable key.
+
+    Args:
+        d: Dictionary to convert.
+
+    Returns:
+        Sorted tuple of (key, value) pairs.
+    """
+    return tuple(sorted(d.items()))
+
+
+def get_haplo_sequence(context_size: int, variants: Any) -> Any:
+    """
+    Construct a haplotype sequence string with flanking genomic context.
+
+    Builds a sequence by combining alternate alleles from each variant with
+    intervening reference sequence, bounded by context_size flanking bases on
+    each side.
+
+    Args:
+        context_size: Number of reference bases to include flanking each end.
+        variants: Hail array expression of variant structs with locus and alleles fields.
+
+    Returns:
+        Hail string expression representing the full haplotype sequence.
+    """
+    sorted_variants = hl.sorted(variants, key=lambda x: x.locus.position)
+    min_variant = sorted_variants[0]
+    max_variant = sorted_variants[-1]
+    min_pos = min_variant.locus.position
+    max_pos = max_variant.locus.position
+    max_variant_size = hl.len(max_variant.alleles[0])
+    full_context = hl.get_sequence(
+        min_variant.locus.contig,
+        min_pos,
+        before=context_size,
+        after=(max_pos - min_pos + max_variant_size + context_size - 1),
+        reference_genome="GRCh38",
+    )
+
+    # (min_pos - index_translation) equals context_size, mapping locus positions to string indices
+    index_translation = min_pos - context_size
+
+    def get_chunk_until_next_variant(i: Any) -> Any:
+        v = sorted_variants[i]
+        variant_size = hl.len(v.alleles[0])
+        reference_buffer_size = hl.if_else(
+            i == hl.len(sorted_variants) - 1,
+            context_size,
+            sorted_variants[i + 1].locus.position - (v.locus.position + variant_size),
+        )
+        start = v.locus.position - index_translation + variant_size
+        return v.alleles[1] + full_context[start : start + reference_buffer_size]
+
+    return full_context[:context_size] + hl.delimit(
+        hl.range(hl.len(sorted_variants)).map(get_chunk_until_next_variant),
+        "",
+    )
+
+
+def variant_distance(v1: Any, v2: Any) -> Any:
+    """
+    Calculate the number of reference bases between two variants.
+
+    For example: 1:1:A:T and 1:3:A:T have distance 1 (one base between them).
+    1:1:AA:T and 1:3:A:T have distance 0 (deletion closes the gap).
+
+    Args:
+        v1: First variant Hail struct with locus and alleles fields.
+        v2: Second variant Hail struct with locus and alleles fields.
+
+    Returns:
+        Hail int32 expression for the number of reference bases between v1 and v2.
+    """
+    return v2.locus.position - v1.locus.position - hl.len(v1.alleles[0])
+
+
+def split_haplotypes(ht: Any, window_size: int) -> Any:
+    """
+    Split multi-variant haplotypes at gaps larger than window_size bases.
+
+    Haplotypes spanning variants further than window_size bases apart are broken
+    into sub-haplotypes at those gaps. Sub-haplotypes with fewer than two variants
+    are discarded.
+
+    Args:
+        ht: Hail table with variants, haplotype, and gnomad_freqs array fields.
+        window_size: Maximum reference bases allowed between adjacent variants in
+            a haplotype segment.
+
+    Returns:
+        Hail table with haplotypes exploded into sub-haplotypes by window.
+    """
+    breakpoints = hl.range(1, hl.len(ht.variants)).filter(
+        lambda i: (i == 0) | (variant_distance(ht.variants[i - 1], ht.variants[i]) >= window_size)
+    )
+
+    def get_range(i: Any) -> Any:
+        start_index = hl.if_else(i == 0, 0, breakpoints[i - 1])
+        end_index = hl.if_else(i == hl.len(breakpoints), hl.len(ht.variants), breakpoints[i])
+        return hl.range(start_index, end_index)
+
+    split_hap_indices = (
+        hl.range(0, hl.len(breakpoints) + 1).map(get_range).filter(lambda r: hl.len(r) > 1)
+    )
+    ht = ht.annotate(haplotype_indices=split_hap_indices)
+    ht = ht.explode("haplotype_indices")
+    ht = ht.annotate(
+        haplotype=ht.haplotype_indices.map(lambda i: ht.haplotype[i]),
+        variants=ht.haplotype_indices.map(lambda i: ht.variants[i]),
+        gnomad_freqs=ht.haplotype_indices.map(lambda i: ht.gnomad_freqs[i]),
+    )
+    return ht.drop("haplotype_indices")

--- a/divref/tests/conftest.py
+++ b/divref/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Shared pytest fixtures for the divref test suite."""
+
+from collections.abc import Generator
+
+import hail as hl
+import pytest
+
+
+@pytest.fixture(scope="session")
+def hail_context() -> Generator[None, None, None]:
+    """
+    Initialize a local Hail context for the test session.
+
+    Starts a local Spark/JVM context once per session and stops it on exit.
+    Tests that use Hail expressions must request this fixture explicitly.
+    Requires Java 11+ to be available in PATH (provided by pixi or setup-java).
+    """
+    hl.init(quiet=True)
+    yield
+    hl.stop()

--- a/divref/tests/test_haplotype.py
+++ b/divref/tests/test_haplotype.py
@@ -1,0 +1,17 @@
+"""Tests for shared Hail utilities in haplotype.py."""
+
+import pytest
+
+from divref.haplotype import get_haplo_sequence
+
+
+def test_get_haplo_sequence_empty_list_raises() -> None:
+    """get_haplo_sequence should raise ValueError when given an empty list."""
+    with pytest.raises(ValueError, match="at least one variant"):
+        get_haplo_sequence(context_size=2, variants=[])
+
+
+def test_get_haplo_sequence_empty_tuple_raises() -> None:
+    """get_haplo_sequence should raise ValueError when given an empty tuple."""
+    with pytest.raises(ValueError, match="at least one variant"):
+        get_haplo_sequence(context_size=2, variants=())

--- a/divref/tests/test_haplotype.py
+++ b/divref/tests/test_haplotype.py
@@ -1,8 +1,20 @@
 """Tests for shared Hail utilities in haplotype.py."""
 
+from typing import Any
+
 import pytest
 
 from divref.haplotype import get_haplo_sequence
+from divref.haplotype import split_haplotypes
+from divref.haplotype import to_hashable_items
+from divref.haplotype import variant_distance
+
+hl = pytest.importorskip("hail")
+
+
+# ---------------------------------------------------------------------------
+# get_haplo_sequence
+# ---------------------------------------------------------------------------
 
 
 def test_get_haplo_sequence_empty_list_raises() -> None:
@@ -15,3 +27,107 @@ def test_get_haplo_sequence_empty_tuple_raises() -> None:
     """get_haplo_sequence should raise ValueError when given an empty tuple."""
     with pytest.raises(ValueError, match="at least one variant"):
         get_haplo_sequence(context_size=2, variants=())
+
+
+# ---------------------------------------------------------------------------
+# to_hashable_items
+# ---------------------------------------------------------------------------
+
+
+def test_to_hashable_items_empty() -> None:
+    assert to_hashable_items({}) == ()
+
+
+def test_to_hashable_items_single_entry() -> None:
+    assert to_hashable_items({"key": "value"}) == (("key", "value"),)
+
+
+def test_to_hashable_items_sorted_by_key() -> None:
+    assert to_hashable_items({"b": 2, "a": 1, "c": 3}) == (("a", 1), ("b", 2), ("c", 3))
+
+
+# ---------------------------------------------------------------------------
+# variant_distance
+# ---------------------------------------------------------------------------
+
+
+def _make_variant(position: int, ref: str, alt: str) -> Any:
+    return hl.Struct(locus=hl.Struct(position=position), alleles=[ref, alt])
+
+
+def test_variant_distance_adjacent_snps(hail_context: None) -> None:  # noqa: ARG001
+    # SNP at 100, next SNP at 101: distance = 101 - 100 - len("A") = 0
+    assert (
+        hl.eval(variant_distance(_make_variant(100, "A", "T"), _make_variant(101, "C", "G"))) == 0
+    )
+
+
+def test_variant_distance_snps_with_gap(hail_context: None) -> None:  # noqa: ARG001
+    # SNP at 100, next SNP at 103: 2 reference bases separate them
+    assert (
+        hl.eval(variant_distance(_make_variant(100, "A", "T"), _make_variant(103, "C", "G"))) == 2
+    )
+
+
+def test_variant_distance_deletion_closes_gap(hail_context: None) -> None:  # noqa: ARG001
+    # Deletion AT→A at 100 (consumes 2 ref bases), next variant at 102: distance = 0
+    assert (
+        hl.eval(variant_distance(_make_variant(100, "AT", "A"), _make_variant(102, "C", "G"))) == 0
+    )
+
+
+# ---------------------------------------------------------------------------
+# split_haplotypes
+# ---------------------------------------------------------------------------
+
+
+def _make_haplotype_table(variant_positions: list[tuple[int, str, str]]) -> Any:
+    variant_type = hl.tstruct(locus=hl.tstruct(position=hl.tint32), alleles=hl.tarray(hl.tstr))
+    row_type = hl.tstruct(
+        variants=hl.tarray(variant_type),
+        haplotype=hl.tarray(hl.tstr),
+        gnomad_freqs=hl.tarray(hl.tfloat64),
+    )
+    variants = [
+        {"locus": {"position": pos}, "alleles": [ref, alt]} for pos, ref, alt in variant_positions
+    ]
+    return hl.Table.parallelize(
+        [
+            {
+                "variants": variants,
+                "haplotype": [str(i) for i in range(len(variants))],
+                "gnomad_freqs": [0.1] * len(variants),
+            }
+        ],
+        schema=row_type,
+    )
+
+
+def test_split_haplotypes_no_split_needed(hail_context: None) -> None:  # noqa: ARG001
+    # All variants within window_size=200; haplotype is kept intact as one row
+    ht = _make_haplotype_table([(100, "A", "T"), (150, "C", "G"), (190, "G", "A")])
+    rows = split_haplotypes(ht, window_size=200).collect()
+    assert len(rows) == 1
+    assert len(rows[0].variants) == 3
+
+
+def test_split_haplotypes_splits_at_large_gap(hail_context: None) -> None:  # noqa: ARG001
+    # Gap between positions 101 and 500 (398 bases) exceeds window_size=200;
+    # results in two sub-haplotypes: [v0, v1] and [v2, v3]
+    ht = _make_haplotype_table([(100, "A", "T"), (101, "C", "G"), (500, "G", "A"), (501, "T", "C")])
+    rows = sorted(
+        split_haplotypes(ht, window_size=200).collect(),
+        key=lambda r: r.variants[0].locus.position,
+    )
+    assert len(rows) == 2
+    assert [v.locus.position for v in rows[0].variants] == [100, 101]
+    assert [v.locus.position for v in rows[1].variants] == [500, 501]
+
+
+def test_split_haplotypes_discards_singleton_segment(hail_context: None) -> None:  # noqa: ARG001
+    # Gap after position 100 isolates it as a singleton (discarded);
+    # only the two-variant segment [500, 501] is kept
+    ht = _make_haplotype_table([(100, "A", "T"), (500, "C", "G"), (501, "G", "A")])
+    rows = split_haplotypes(ht, window_size=200).collect()
+    assert len(rows) == 1
+    assert [v.locus.position for v in rows[0].variants] == [500, 501]

--- a/pixi.lock
+++ b/pixi.lock
@@ -98,7 +98,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjdk-25.0.2-ha668962_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjdk-11.0.30-ha668962_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
@@ -290,7 +290,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjdk-25.0.2-h48c29e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjdk-11.0.30-h48c29e7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
@@ -466,7 +466,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjdk-25.0.2-h258754b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjdk-11.0.30-h258754b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
@@ -3214,9 +3214,9 @@ packages:
   - pyjwt>=2.0.0,<3 ; extra == 'signedtoken'
   - blinker>=1.4.0 ; extra == 'signals'
   requires_python: '>=3.8'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openjdk-25.0.2-ha668962_0.conda
-  sha256: 3825a4c84676a8a5cc23b397a2911e4efa4a805daf2af764153bd904e142ec41
-  md5: a41092b0177362dbe5eb2a18501e86c0
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjdk-11.0.30-ha668962_0.conda
+  sha256: 8b1634c3474618a4e60ca0198fac15bbc63b5fe901c6af254f411b3a207007c5
+  md5: 2c14def92acbb67d6f20cf9fe60c9f68
   depends:
   - xorg-libx11
   - xorg-libxext
@@ -3226,52 +3226,52 @@ packages:
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - xorg-libxrender >=0.9.12,<0.10.0a0
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - xorg-libxrandr >=1.5.5,<2.0a0
   - harfbuzz >=12.3.2
-  - fontconfig >=2.17.1,<3.0a0
-  - fonts-conda-ecosystem
-  - xorg-libxtst >=1.2.5,<2.0a0
-  - xorg-libxi >=1.8.2,<2.0a0
-  - lcms2 >=2.18,<3.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xorg-libxt >=1.3.1,<2.0a0
   - alsa-lib >=1.2.15.3,<1.3.0a0
   - libpng >=1.6.55,<1.7.0a0
-  - xorg-libxt >=1.3.1,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - xorg-libxext >=1.3.7,<2.0a0
-  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-libxi >=1.8.2,<2.0a0
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
   - libcups >=2.3.3,<2.4.0a0
+  - lcms2 >=2.18,<3.0a0
+  - xorg-libxtst >=1.2.5,<2.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - fontconfig >=2.17.1,<3.0a0
+  - fonts-conda-ecosystem
+  - xorg-libxrandr >=1.5.5,<2.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
   license: GPL-2.0-or-later WITH Classpath-exception-2.0
   license_family: GPL
   purls: []
-  size: 122465031
-  timestamp: 1771443671180
-- conda: https://conda.anaconda.org/conda-forge/osx-64/openjdk-25.0.2-h48c29e7_0.conda
-  sha256: 6d75a78b11aa1100d8dda8b860ebd2943c0ba137cf87c205351ee2c02434cb23
-  md5: 7039d4add86c40fed1ff9371d405391f
+  size: 176392296
+  timestamp: 1771444098245
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openjdk-11.0.30-h48c29e7_0.conda
+  sha256: 68a4a30153cf9a99d0107835fbbd3da4206d8a26082ebd5c6cefc4a6a241e95a
+  md5: 99da0dbd652a47bad774279d8f2cae78
   depends:
   - __osx >=11.0
   - libzlib >=1.3.1,<2.0a0
   license: GPL-2.0-or-later WITH Classpath-exception-2.0
   license_family: GPL
   purls: []
-  size: 201289992
-  timestamp: 1771443806108
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjdk-25.0.2-h258754b_0.conda
-  sha256: f6f06243c1a35b6590f06be386bd5cefc5b1773b985a61b7917b93dab4cf18ec
-  md5: a4024e03865a7411c1028eac83d1956c
+  size: 170823996
+  timestamp: 1771444034506
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjdk-11.0.30-h258754b_0.conda
+  sha256: 87c11ac17a85287481a1e7fd96653a1a13848d4691cd877234f303ab678384d8
+  md5: b065e9fc471274cfbb4e5a2b69b17555
   depends:
   - __osx >=11.0
   - libzlib >=1.3.1,<2.0a0
   license: GPL-2.0-or-later WITH Classpath-exception-2.0
   license_family: GPL
   purls: []
-  size: 199165105
-  timestamp: 1771443790144
+  size: 168935939
+  timestamp: 1771444130710
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
   sha256: c0ef482280e38c71a08ad6d71448194b719630345b0c9c60744a2010e8a8e0cb
   md5: da1b85b6a87e141f5140bb9924cecab0

--- a/pixi.toml
+++ b/pixi.toml
@@ -14,7 +14,7 @@ snakefmt = ">=1.0.0,<2"
 divref = { path = "./divref", editable = true }
 
 [feature.hail.dependencies]
-openjdk = ">=11"
+openjdk = ">=11,<17"
 
 [environments]
 default = { features = ["snakemake", "hail"] }


### PR DESCRIPTION
## Summary

- Adds `divref/haplotype.py` with shared helpers used across multiple Hail-based pipeline tools:
  - `HailPath` — type alias for paths accepted by Hail (`str`, accepting local, `gs://`, `hdfs://`)
  - `to_hashable_items` — converts a Hail struct to a hashable tuple for use as a dict key
  - `get_haplo_sequence` — builds haplotype sequence strings with flanking reference context
  - `variant_distance` — computes the distance between two variants
  - `split_haplotypes` — splits multi-variant haplotypes at gaps larger than `window_size` bases

## Test plan

- [ ] `uv run --directory divref poe check-all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Haplotype processing utilities for reconstructing sequences with genomic flanking context and segmenting variants by spacing.
* **Bug Fixes / Improvements**
  * Improved handling of variant distances and sequence assembly to yield consistent haplotype outputs.
* **Tests**
  * Added comprehensive tests covering sequence reconstruction, hashing behavior, distance calculations, and window-based splitting.
* **Chores**
  * CI: ensure Java runtime is configured for tests; restrict supported OpenJDK versions for Hail-related workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->