### PR TITLE
feat: add rewrite_fasta tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,4 @@
 !.pixi/config.toml
 
 # claude
-**/claude
+**/.claude

--- a/divref/divref/tools/rewrite_fasta.py
+++ b/divref/divref/tools/rewrite_fasta.py
@@ -1,0 +1,30 @@
+"""Tool to filter a FASTA file to canonical chromosomes only."""
+
+from pathlib import Path
+
+import tqdm
+
+
+def rewrite_fasta(*, fasta_path: Path, output_path: Path) -> None:
+    """
+    Rewrite a FASTA file keeping only canonical chromosomes (chr1-22, X, Y, MT).
+
+    Filters out alt contigs, decoy sequences, and any other non-canonical sequences.
+    Reads the input file line by line so it can handle arbitrarily large FASTA files.
+
+    Args:
+        fasta_path: Path to the input FASTA file.
+        output_path: Path to write the filtered FASTA file.
+    """
+    contigs_to_keep = {f"chr{i}" for i in range(1, 23)} | {"chrX", "chrY", "chrMT"}
+
+    keep = False
+    with open(fasta_path) as f, open(output_path, "w") as out:
+        for line in tqdm.tqdm(f):
+            if line[0] == ">":
+                contig = line.split()[0][1:]
+                keep = contig in contigs_to_keep
+                if keep:
+                    out.write(line)
+            elif keep:
+                out.write(line)

--- a/divref/tests/tools/test_rewrite_fasta.py
+++ b/divref/tests/tools/test_rewrite_fasta.py
@@ -1,0 +1,53 @@
+"""Tests for the rewrite_fasta tool."""
+
+from pathlib import Path
+
+from divref.tools.rewrite_fasta import rewrite_fasta
+
+
+def _write_fasta(path: Path, contigs: list[tuple[str, str]]) -> None:
+    with open(path, "w") as f:
+        for name, seq in contigs:
+            f.write(f">{name}\n{seq}\n")
+
+
+def test_keeps_canonical_autosomes(tmp_path: Path) -> None:
+    _write_fasta(tmp_path / "in.fa", [("chr1", "ACGT"), ("chr22", "TTTT")])
+    rewrite_fasta(fasta_path=tmp_path / "in.fa", output_path=tmp_path / "out.fa")
+    assert (tmp_path / "out.fa").read_text() == ">chr1\nACGT\n>chr22\nTTTT\n"
+
+
+def test_keeps_sex_and_mt_chromosomes(tmp_path: Path) -> None:
+    _write_fasta(tmp_path / "in.fa", [("chrX", "AAAA"), ("chrY", "CCCC"), ("chrMT", "GGGG")])
+    rewrite_fasta(fasta_path=tmp_path / "in.fa", output_path=tmp_path / "out.fa")
+    assert (tmp_path / "out.fa").read_text() == ">chrX\nAAAA\n>chrY\nCCCC\n>chrMT\nGGGG\n"
+
+
+def test_filters_non_canonical(tmp_path: Path) -> None:
+    _write_fasta(
+        tmp_path / "in.fa",
+        [("chr1", "ACGT"), ("chr1_alt", "AAAA"), ("chrUn_gl000220", "TTTT")],
+    )
+    rewrite_fasta(fasta_path=tmp_path / "in.fa", output_path=tmp_path / "out.fa")
+    assert (tmp_path / "out.fa").read_text() == ">chr1\nACGT\n"
+
+
+def test_mixed_canonical_and_non_canonical(tmp_path: Path) -> None:
+    _write_fasta(
+        tmp_path / "in.fa",
+        [("chr1", "ACGT"), ("chr1_alt", "AAAA"), ("chr2", "TTTT"), ("chrEBV", "CCCC")],
+    )
+    rewrite_fasta(fasta_path=tmp_path / "in.fa", output_path=tmp_path / "out.fa")
+    assert (tmp_path / "out.fa").read_text() == ">chr1\nACGT\n>chr2\nTTTT\n"
+
+
+def test_empty_fasta(tmp_path: Path) -> None:
+    (tmp_path / "in.fa").write_text("")
+    rewrite_fasta(fasta_path=tmp_path / "in.fa", output_path=tmp_path / "out.fa")
+    assert (tmp_path / "out.fa").read_text() == ""
+
+
+def test_multiline_sequence_preserved(tmp_path: Path) -> None:
+    (tmp_path / "in.fa").write_text(">chr1\nACGT\nTGCA\n>chr1_alt\nAAAA\n")
+    rewrite_fasta(fasta_path=tmp_path / "in.fa", output_path=tmp_path / "out.fa")
+    assert (tmp_path / "out.fa").read_text() == ">chr1\nACGT\nTGCA\n"


### PR DESCRIPTION
## Summary

- Ports `rewrite_fasta.py` from `human-diversity-reference/scripts` as a defopt-compatible toolkit tool
- Filters a FASTA file to retain only canonical chromosomes (`chr1–22`, `X`, `Y`, `MT`)
- Fixes a potential `UnboundLocalError` in the original by initialising `keep=False` before the loop
- Removes the unused `header_line` variable from the original

## Test plan

- [ ] `uv run --directory divref poe check-all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FASTA filtering tool to retain only canonical chromosome contigs (chr1–chr22, chrX, chrY, chrMT) while removing non-canonical sequences.

* **Tests**
  * Added comprehensive test coverage for FASTA filtering functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->