### PR TITLE
feat: add create_gnomad_sites_vcf tool

### DIFF
--- a/divref/divref/defaults.py
+++ b/divref/divref/defaults.py
@@ -11,3 +11,6 @@ GNOMAD_HGDP_1KG_SAMPLE_METADATA_HAIL_TABLE: Final[HailPath] = (
     "gs://gcp-public-data--gnomad/release/3.1.2/ht/genomes/gnomad.genomes.v3.1.2.hgdp_1kg_subset_sample_meta.ht"  # noqa: E501
 )
 """HGDP+1KG sample metadata."""
+
+POPULATIONS: list[str] = ["afr", "amr", "eas", "sas", "nfe"]
+"""Default HGDP+1KG populations."""

--- a/divref/divref/defaults.py
+++ b/divref/divref/defaults.py
@@ -14,3 +14,6 @@ GNOMAD_HGDP_1KG_SAMPLE_METADATA_HAIL_TABLE: Final[HailPath] = (
 
 POPULATIONS: list[str] = ["afr", "amr", "eas", "sas", "nfe"]
 """Default HGDP+1KG populations."""
+
+REFERENCE_GENOME: str = "GRCh38"
+"""Default reference genome assembly."""

--- a/divref/divref/haplotype.py
+++ b/divref/divref/haplotype.py
@@ -6,6 +6,8 @@ from typing import TypeVar
 
 import hail as hl
 
+from divref import defaults
+
 _V = TypeVar("_V", bound=Hashable)
 """Type variable for hashable dictionary values used in to_hashable_items."""
 
@@ -23,7 +25,9 @@ def to_hashable_items(d: dict[str, _V]) -> tuple[tuple[str, _V], ...]:
     return tuple(sorted(d.items()))
 
 
-def get_haplo_sequence(context_size: int, variants: Any, reference_genome: str = "GRCh38") -> Any:
+def get_haplo_sequence(
+    context_size: int, variants: Any, reference_genome: str = defaults.REFERENCE_GENOME
+) -> Any:
     """
     Construct a haplotype sequence string with flanking genomic context.
 

--- a/divref/divref/main.py
+++ b/divref/divref/main.py
@@ -5,11 +5,13 @@ from typing import List
 
 import defopt
 
+from divref.tools.create_gnomad_sites_vcf import create_gnomad_sites_vcf
 from divref.tools.extract_gnomad_afs import extract_gnomad_afs
 from divref.tools.extract_sample_metadata import extract_sample_metadata
 from divref.tools.gnomad_hail_table_test_data import gnomad_hail_table_test_data
 
 _tools: List[Callable[..., None]] = [
+    create_gnomad_sites_vcf,
     extract_gnomad_afs,
     extract_sample_metadata,
     gnomad_hail_table_test_data,

--- a/divref/divref/main.py
+++ b/divref/divref/main.py
@@ -6,10 +6,12 @@ from typing import List
 import defopt
 
 from divref.tools.extract_gnomad_afs import extract_gnomad_afs
+from divref.tools.extract_sample_metadata import extract_sample_metadata
 from divref.tools.gnomad_hail_table_test_data import gnomad_hail_table_test_data
 
 _tools: List[Callable[..., None]] = [
     extract_gnomad_afs,
+    extract_sample_metadata,
     gnomad_hail_table_test_data,
 ]
 

--- a/divref/divref/tools/create_gnomad_sites_vcf.py
+++ b/divref/divref/tools/create_gnomad_sites_vcf.py
@@ -1,8 +1,11 @@
 """Tool to export gnomAD variants above a frequency threshold as a VCF file."""
 
+from pathlib import Path
+
 import hail as hl
 
-from divref.haplotype import HailPath
+from divref.alias import HailPath
+from divref.hail import hail_init
 
 
 def create_gnomad_sites_vcf(
@@ -10,6 +13,7 @@ def create_gnomad_sites_vcf(
     sites_table_path: HailPath,
     output_vcf_path: HailPath,
     min_popmax: float,
+    gcs_credentials_path: Path = Path("~/.config/gcloud/application_default_credentials.json"),
 ) -> None:
     """
     Export gnomAD variant sites above a population frequency threshold as VCF.
@@ -19,12 +23,12 @@ def create_gnomad_sites_vcf(
     per-population frequency fields into VCF INFO format, and exports as VCF.
 
     Args:
-        sites_table_path: Path to the gnomAD variant annotations Hail table
-            (from extract_gnomad_afs).
+        sites_table_path: Path to the gnomAD variant annotations Hail table.
         output_vcf_path: Output path for the VCF file.
         min_popmax: Minimum allele frequency in any population to include a site.
+        gcs_credentials_path: Path to GCS default credentials JSON file.
     """
-    hl.init()
+    hail_init(gcs_credentials_path.expanduser())
 
     ht = hl.read_table(sites_table_path)
     pops: list[str] = ht.pops.collect()[0]

--- a/divref/divref/tools/create_gnomad_sites_vcf.py
+++ b/divref/divref/tools/create_gnomad_sites_vcf.py
@@ -23,7 +23,8 @@ def create_gnomad_sites_vcf(
     per-population frequency fields into VCF INFO format, and exports as VCF.
 
     Args:
-        sites_table_path: Path to the gnomAD variant annotations Hail table.
+        sites_table_path: Path to the gnomAD variant annotations Hail table output from
+            `extract-gnomad-afs`.
         output_vcf_path: Output path for the VCF file.
         min_popmax: Minimum allele frequency in any population to include a site.
         gcs_credentials_path: Path to GCS default credentials JSON file.
@@ -33,7 +34,7 @@ def create_gnomad_sites_vcf(
     ht = hl.read_table(sites_table_path)
     pops: list[str] = ht.pops.collect()[0]
 
-    filt = ht.filter(hl.max(ht.pop_freqs[0].map(lambda x: x.AF)) >= min_popmax)
+    filt = ht.filter(hl.max(ht.pop_freqs.map(lambda x: x.AF)) >= min_popmax)
     filt = filt.annotate(
         info=hl.struct(**{
             f"{pop}_{fd}": filt.pop_freqs[i][fd]

--- a/divref/divref/tools/create_gnomad_sites_vcf.py
+++ b/divref/divref/tools/create_gnomad_sites_vcf.py
@@ -1,0 +1,40 @@
+"""Tool to export gnomAD variants above a frequency threshold as a VCF file."""
+
+import hail as hl
+
+from divref.haplotype import HailPath
+
+
+def create_gnomad_sites_vcf(
+    *,
+    sites_table_path: HailPath,
+    output_vcf_path: HailPath,
+    min_popmax: float,
+) -> None:
+    """
+    Export gnomAD variant sites above a population frequency threshold as VCF.
+
+    Filters the gnomAD variant annotations table to sites where at least one
+    population's allele frequency meets or exceeds min_popmax, restructures
+    per-population frequency fields into VCF INFO format, and exports as VCF.
+
+    Args:
+        sites_table_path: Path to the gnomAD variant annotations Hail table
+            (from extract_gnomad_afs).
+        output_vcf_path: Output path for the VCF file.
+        min_popmax: Minimum allele frequency in any population to include a site.
+    """
+    hl.init()
+
+    ht = hl.read_table(sites_table_path)
+    pops: list[str] = ht.pops.collect()[0]
+
+    filt = ht.filter(hl.max(ht.pop_freqs[0].map(lambda x: x.AF)) >= min_popmax)
+    filt = filt.annotate(
+        info=hl.struct(**{
+            f"{pop}_{fd}": filt.pop_freqs[i][fd]
+            for i, pop in enumerate(pops)
+            for fd in filt.pop_freqs[i]
+        })
+    )
+    hl.export_vcf(filt, output_vcf_path)

--- a/divref/divref/tools/extract_gnomad_afs.py
+++ b/divref/divref/tools/extract_gnomad_afs.py
@@ -4,22 +4,18 @@ from pathlib import Path
 
 import hail as hl
 
+from divref import defaults
 from divref.alias import HailPath
 from divref.hail import hail_init
 from divref.haplotype import to_hashable_items
-
-DEFAULT_POPULATIONS: list[str] = ["afr", "amr", "eas", "sas", "nfe"]
-"""Default populations to extract AFs for."""
 
 
 def extract_gnomad_afs(
     *,
     in_gnomad_sites_table: HailPath,
-    in_gnomad_hgdp_sample_data: HailPath,
     out_variant_annotation_table: HailPath,
-    out_sample_metadata: HailPath,
     freq_threshold: float = 0.001,
-    populations: list[str] = DEFAULT_POPULATIONS,
+    populations: list[str] = defaults.POPULATIONS,
     gcs_credentials_path: Path = Path("~/.config/gcloud/application_default_credentials.json"),
 ) -> None:
     """
@@ -31,9 +27,7 @@ def extract_gnomad_afs(
 
     Args:
         in_gnomad_sites_table: Path to the gnomAD HGDP/1KG sites table.
-        in_gnomad_hgdp_sample_data: Path to the gnomAD HGDP/1KG sample metadata table.
         out_variant_annotation_table: Output path for the variant annotation Hail table.
-        out_sample_metadata: Output path for the sample metadata Hail table.
         freq_threshold: Minimum allele frequency in any population to retain a variant.
         populations: List of population codes to extract frequencies for.
         gcs_credentials_path: Path to GCS default credentials JSON file.
@@ -59,7 +53,3 @@ def extract_gnomad_afs(
     va = va.select(pop_freqs=hl.literal(pop_indices).map(lambda i: va.gnomad_freq[i]))
     va = va.filter(hl.any(lambda x: x.AF > freq_threshold, va.pop_freqs))
     va.naive_coalesce(64).write(out_variant_annotation_table, overwrite=True)
-
-    sa = hl.read_table(in_gnomad_hgdp_sample_data).select_globals()
-    sa = sa.select(pop=sa.gnomad_population_inference.pop)
-    sa.naive_coalesce(4).write(out_sample_metadata, overwrite=True)

--- a/divref/divref/tools/extract_gnomad_afs.py
+++ b/divref/divref/tools/extract_gnomad_afs.py
@@ -14,8 +14,10 @@ def extract_gnomad_afs(
     *,
     in_gnomad_sites_table: HailPath,
     out_variant_annotation_table: HailPath,
+    contig: str,
     freq_threshold: float = 0.001,
     populations: list[str] = defaults.POPULATIONS,
+    reference_genome: str = defaults.REFERENCE_GENOME,
     gcs_credentials_path: Path = Path("~/.config/gcloud/application_default_credentials.json"),
 ) -> None:
     """
@@ -28,13 +30,17 @@ def extract_gnomad_afs(
     Args:
         in_gnomad_sites_table: Path to the gnomAD HGDP/1KG sites table.
         out_variant_annotation_table: Output path for the variant annotation Hail table.
+        contig: Contig to extract sites.
         freq_threshold: Minimum allele frequency in any population to retain a variant.
         populations: List of population codes to extract frequencies for.
+        reference_genome: Reference genome to use. Defaults to "GRCh38".
         gcs_credentials_path: Path to GCS default credentials JSON file.
     """
     hail_init(gcs_credentials_path.expanduser())
 
-    va = hl.read_table(in_gnomad_sites_table)
+    va_all = hl.read_table(in_gnomad_sites_table)
+    interval = hl.parse_locus_interval(contig, reference_genome=reference_genome)
+    va = hl.filter_intervals(va_all, [interval])
 
     freq_meta = va.globals.gnomad_freq_meta.collect()[0]
     map_to_index = {to_hashable_items(x): i for i, x in enumerate(freq_meta)}

--- a/divref/divref/tools/extract_sample_metadata.py
+++ b/divref/divref/tools/extract_sample_metadata.py
@@ -1,4 +1,4 @@
-"""Tool to extract gnomAD variant and sample frequency data for the DivRef pipeline."""
+"""Tool to extract gnomAD sample metadata for the DivRef pipeline."""
 
 from pathlib import Path
 

--- a/divref/divref/tools/extract_sample_metadata.py
+++ b/divref/divref/tools/extract_sample_metadata.py
@@ -7,9 +7,6 @@ import hail as hl
 from divref.alias import HailPath
 from divref.hail import hail_init
 
-DEFAULT_POPULATIONS: list[str] = ["afr", "amr", "eas", "sas", "nfe"]
-"""Default populations to extract AFs for."""
-
 
 def extract_sample_metadata(
     *,

--- a/divref/divref/tools/extract_sample_metadata.py
+++ b/divref/divref/tools/extract_sample_metadata.py
@@ -1,0 +1,32 @@
+"""Tool to extract gnomAD variant and sample frequency data for the DivRef pipeline."""
+
+from pathlib import Path
+
+import hail as hl
+
+from divref.alias import HailPath
+from divref.hail import hail_init
+
+DEFAULT_POPULATIONS: list[str] = ["afr", "amr", "eas", "sas", "nfe"]
+"""Default populations to extract AFs for."""
+
+
+def extract_sample_metadata(
+    *,
+    in_gnomad_hgdp_sample_data: HailPath,
+    out_sample_metadata: HailPath,
+    gcs_credentials_path: Path = Path("~/.config/gcloud/application_default_credentials.json"),
+) -> None:
+    """
+    Extract sample metadata for downstream pipeline tools.
+
+    Args:
+        in_gnomad_hgdp_sample_data: Path to the gnomAD HGDP/1KG sample metadata table.
+        out_sample_metadata: Output path for the sample metadata Hail table.
+        gcs_credentials_path: Path to GCS default credentials JSON file.
+    """
+    hail_init(gcs_credentials_path.expanduser())
+
+    sa = hl.read_table(in_gnomad_hgdp_sample_data).select_globals()
+    sa = sa.select(pop=sa.gnomad_population_inference.pop)
+    sa.naive_coalesce(4).write(out_sample_metadata, overwrite=True)

--- a/divref/divref/tools/gnomad_hail_table_test_data.py
+++ b/divref/divref/tools/gnomad_hail_table_test_data.py
@@ -44,7 +44,7 @@ def gnomad_hail_table_test_data(
     hail_init(gcs_credentials_path.expanduser())
 
     va = hl.read_table(in_gnomad_hgdp_variant_annotation_table)
-    roi = [hl.parse_locus_interval(locus, reference_genome="GRCh38")]
+    roi = [hl.parse_locus_interval(locus, reference_genome=defaults.REFERENCE_GENOME)]
 
     logger.info(f"Filtering to {locus} and sampling {sample_proportion} of variants.")
     va_subset = hl.filter_intervals(va, roi).sample(sample_proportion, seed)

--- a/divref/tests/tools/test_create_gnomad_sites_vcf.py
+++ b/divref/tests/tools/test_create_gnomad_sites_vcf.py
@@ -1,0 +1,57 @@
+"""Tests for the create_gnomad_sites_vcf tool."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import hail as hl
+
+from divref import defaults
+from divref.tools.create_gnomad_sites_vcf import create_gnomad_sites_vcf
+from divref.tools.extract_gnomad_afs import extract_gnomad_afs
+
+
+def test_create_gnomad_sites_vcf(
+    hail_context: None,  # noqa: ARG001
+    datadir: Path,
+    tmp_path: Path,
+) -> None:
+    """Happy-path: filter extracted AFs and export as VCF."""
+    # --- setup: run extract_gnomad_afs to produce the input table ---
+    in_sites = str(datadir / "chr1_100001_200000_0.01_seed42.ht")
+    extracted_table = str(tmp_path / "extracted.ht")
+
+    with patch("divref.tools.extract_gnomad_afs.hail_init"):
+        extract_gnomad_afs(
+            in_gnomad_sites_table=in_sites,
+            out_variant_annotation_table=extracted_table,
+            contig="chr1",
+            populations=defaults.POPULATIONS,
+            reference_genome=defaults.REFERENCE_GENOME,
+        )
+
+    # --- act: run create_gnomad_sites_vcf ---
+    output_vcf = str(tmp_path / "output.vcf.bgz")
+
+    with patch("divref.tools.create_gnomad_sites_vcf.hail_init"):
+        create_gnomad_sites_vcf(
+            sites_table_path=extracted_table,
+            output_vcf_path=output_vcf,
+            min_popmax=0.01,
+        )
+
+    # --- assert: VCF file is valid ---
+    vcf = hl.import_vcf(output_vcf, reference_genome=defaults.REFERENCE_GENOME)
+    vcf_count = vcf.count_rows()
+    assert vcf_count == 3
+
+    # INFO fields should contain population-prefixed frequency entries
+    info_fields = list(vcf.row.info.dtype)
+    for pop in defaults.POPULATIONS:
+        assert any(f.startswith(f"{pop}_") for f in info_fields), (
+            f"Expected INFO fields for population {pop}"
+        )
+
+    # VCF should have equal or fewer variants than the unfiltered extracted table
+    extracted = hl.read_table(extracted_table)
+    extracted_count = extracted.count()
+    assert vcf_count <= extracted_count

--- a/divref/tests/tools/test_extract_gnomad_afs.py
+++ b/divref/tests/tools/test_extract_gnomad_afs.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import hail as hl
 
-from divref.tools.extract_gnomad_afs import DEFAULT_POPULATIONS
+from divref import defaults
 from divref.tools.extract_gnomad_afs import extract_gnomad_afs
 
 
@@ -16,42 +16,29 @@ def test_extract_gnomad_afs(
 ) -> None:
     """Happy-path: extract AFs from local test variant and sample data."""
     in_sites = str(datadir / "chr1_100001_200000_0.01_seed42.ht")
-    in_samples = str(datadir / "hgdp_1kg_sample_metadata.ht")
     out_va = str(tmp_path / "va.ht")
-    out_sa = str(tmp_path / "sa.ht")
 
     with patch("divref.tools.extract_gnomad_afs.hail_init"):
         extract_gnomad_afs(
             in_gnomad_sites_table=in_sites,
-            in_gnomad_hgdp_sample_data=in_samples,
             out_variant_annotation_table=out_va,
-            out_sample_metadata=out_sa,
+            freq_threshold=0.001,
+            populations=defaults.POPULATIONS,
         )
 
-    # --- variant annotation table ---
     va = hl.read_table(out_va)
     va_count = va.count()
-    assert va_count > 0, "Expected at least one variant after filtering"
+    assert va_count == 11
 
     # Globals should contain the requested populations
     pops = hl.eval(va.globals.pops)
-    assert pops == DEFAULT_POPULATIONS
+    assert pops == defaults.POPULATIONS
 
     # Each row should have pop_freqs with one entry per population
     first_row = va.head(1).collect()[0]
-    assert len(first_row.pop_freqs) == len(DEFAULT_POPULATIONS)
+    assert len(first_row.pop_freqs) == len(defaults.POPULATIONS)
     assert all(hasattr(f, "AF") for f in first_row.pop_freqs)
 
     # All retained variants must exceed freq_threshold in at least one population
     min_max_af = va.aggregate(hl.agg.min(hl.max(va.pop_freqs.map(lambda x: x.AF))))
     assert min_max_af > 0.001
-
-    # --- sample metadata table ---
-    sa = hl.read_table(out_sa)
-    sa_count = sa.count()
-    assert sa_count > 0, "Expected at least one sample"
-
-    # Each sample should have a pop field
-    first_sample = sa.head(1).collect()[0]
-    assert hasattr(first_sample, "pop")
-    assert isinstance(first_sample.pop, str)

--- a/divref/tests/tools/test_extract_gnomad_afs.py
+++ b/divref/tests/tools/test_extract_gnomad_afs.py
@@ -22,8 +22,10 @@ def test_extract_gnomad_afs(
         extract_gnomad_afs(
             in_gnomad_sites_table=in_sites,
             out_variant_annotation_table=out_va,
+            contig="chr1",
             freq_threshold=0.001,
             populations=defaults.POPULATIONS,
+            reference_genome=defaults.REFERENCE_GENOME,
         )
 
     va = hl.read_table(out_va)

--- a/divref/tests/tools/test_extract_sample_metadata.py
+++ b/divref/tests/tools/test_extract_sample_metadata.py
@@ -13,7 +13,7 @@ def test_extract_sample_metadata(
     datadir: Path,
     tmp_path: Path,
 ) -> None:
-    """Happy-path: extract AFs from local test variant and sample data."""
+    """Happy-path: extract sample metadata from local test data."""
     in_samples = str(datadir / "hgdp_1kg_sample_metadata.ht")
     out_sa = str(tmp_path / "sa.ht")
 

--- a/divref/tests/tools/test_extract_sample_metadata.py
+++ b/divref/tests/tools/test_extract_sample_metadata.py
@@ -1,4 +1,4 @@
-"""Tests for the extract_gnomad_afs tool."""
+"""Tests for the extract_sample_metadata tool."""
 
 from pathlib import Path
 from unittest.mock import patch

--- a/divref/tests/tools/test_extract_sample_metadata.py
+++ b/divref/tests/tools/test_extract_sample_metadata.py
@@ -1,0 +1,33 @@
+"""Tests for the extract_gnomad_afs tool."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import hail as hl
+
+from divref.tools.extract_sample_metadata import extract_sample_metadata
+
+
+def test_extract_sample_metadata(
+    hail_context: None,  # noqa: ARG001
+    datadir: Path,
+    tmp_path: Path,
+) -> None:
+    """Happy-path: extract AFs from local test variant and sample data."""
+    in_samples = str(datadir / "hgdp_1kg_sample_metadata.ht")
+    out_sa = str(tmp_path / "sa.ht")
+
+    with patch("divref.tools.extract_sample_metadata.hail_init"):
+        extract_sample_metadata(
+            in_gnomad_hgdp_sample_data=in_samples,
+            out_sample_metadata=out_sa,
+        )
+
+    sa = hl.read_table(out_sa)
+    sa_count = sa.count()
+    assert sa_count == 4151
+
+    # Each sample should have a pop field
+    first_sample = sa.head(1).collect()[0]
+    assert hasattr(first_sample, "pop")
+    assert isinstance(first_sample.pop, str)

--- a/pixi.toml
+++ b/pixi.toml
@@ -39,7 +39,7 @@ setup-gcs = """
 python -c "
 import os, urllib.request, zipfile, hashlib
 jar = os.path.join(__import__('pyspark').__path__[0], 'jars', 'gcs-connector.jar')
-expected_sha256 = "d53cd19ec2fadc3f81319a1dcf3f70940915a674781c29a7067ea6021ae8dfe2"
+expected_sha256 = 'd53cd19ec2fadc3f81319a1dcf3f70940915a674781c29a7067ea6021ae8dfe2'
 valid = False
 if os.path.exists(jar):
     try:


### PR DESCRIPTION
## Summary

- Add `create_gnomad_sites_vcf` tool that filters gnomAD variant annotations by a population frequency threshold and exports them as a VCF with per-population frequency INFO fields
- Split `extract_gnomad_afs` into two tools: `extract_gnomad_afs` (variant annotations, now works one chromosome at a time) and `extract_sample_metadata` (sample population assignments)
- Fix `create_gnomad_sites_vcf` bug where `pop_freqs[0].map(...)` operated on a single struct instead of the full array — corrected to `pop_freqs.map(...)`
- Fix `pixi run setup-gcs` task (was `pixi setup-gcs`)
- Add happy-path tests for `create_gnomad_sites_vcf` and `extract_sample_metadata`
- Add `POPULATIONS` and `REFERENCE_GENOME` constants to `defaults.py`

## Test plan

- [x] `uv run --directory divref poe check-all` passes (format, lint, mypy, all tests)
- [x] `test_create_gnomad_sites_vcf` chains `extract_gnomad_afs` → `create_gnomad_sites_vcf`, validates VCF row count, population-prefixed INFO fields, and filtering correctness
- [x] `test_extract_gnomad_afs` validates variant count, population globals, frequency schema, and threshold filtering
- [x] `test_extract_sample_metadata` validates sample metadata extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new CLI commands for creating gnomAD sites VCF files and extracting sample metadata from gnomAD datasets.
  * Introduced centralized default configuration for reference genome and population definitions across the application.

* **Improvements**
  * Enhanced the gnomAD allele frequency extraction tool with improved parameter handling and filtering capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->