### PR TITLE
feat: add compute_variation_ratios tool

### DIFF
--- a/divref/divref/defaults.py
+++ b/divref/divref/defaults.py
@@ -17,3 +17,6 @@ POPULATIONS: list[str] = ["afr", "amr", "eas", "sas", "nfe"]
 
 REFERENCE_GENOME: str = "GRCh38"
 """Default reference genome assembly."""
+
+VARIATION_RATIO_FREQUENCY_THRESHOLDS = [0, 0.0001, 0.001, 0.005, 0.01, 0.05, 0.1]
+"""Default frequency thresholds for variation ratio calculation."""

--- a/divref/divref/main.py
+++ b/divref/divref/main.py
@@ -7,6 +7,7 @@ import defopt
 
 from divref.tools.compute_haplotype_statistics import compute_haplotype_statistics
 from divref.tools.compute_haplotypes import compute_haplotypes
+from divref.tools.compute_variation_ratios import compute_variation_ratios
 from divref.tools.create_gnomad_sites_vcf import create_gnomad_sites_vcf
 from divref.tools.extract_gnomad_afs import extract_gnomad_afs
 from divref.tools.extract_sample_metadata import extract_sample_metadata
@@ -15,6 +16,7 @@ from divref.tools.gnomad_hail_table_test_data import gnomad_hail_table_test_data
 _tools: List[Callable[..., None]] = [
     compute_haplotypes,
     compute_haplotype_statistics,
+    compute_variation_ratios,
     create_gnomad_sites_vcf,
     extract_gnomad_afs,
     extract_sample_metadata,

--- a/divref/divref/tools/compute_variation_ratios.py
+++ b/divref/divref/tools/compute_variation_ratios.py
@@ -2,7 +2,7 @@
 
 import hail as hl
 
-from divref.haplotype import HailPath
+from divref.alias import HailPath
 
 _FREQ_THRESHOLDS = [0, 0.0001, 0.001, 0.005, 0.01, 0.05, 0.1]
 

--- a/divref/divref/tools/compute_variation_ratios.py
+++ b/divref/divref/tools/compute_variation_ratios.py
@@ -30,6 +30,13 @@ def compute_variation_ratios(
         output_ht: Output path for the sample-level Hail table.
         frequency_thresholds: Frequency thresholds to calculate.
     """
+    if any(t < 0 or t > 1 for t in frequency_thresholds):
+        raise ValueError("All frequency_thresholds must be in [0, 1].")
+
+    threshold_keys = [format(t, ".6g") for t in frequency_thresholds]
+    if len(set(threshold_keys)) != len(threshold_keys):
+        raise ValueError("frequency_thresholds produce duplicate output field names.")
+
     hl.init()
 
     gnomad_sa = hl.read_table(gnomad_sa_file)
@@ -39,13 +46,15 @@ def compute_variation_ratios(
     mt = mt.select_rows().select_cols()
     mt = mt.annotate_rows(freq=gnomad_va[mt.row_key].pop_freqs)
     mt = mt.filter_rows(hl.is_defined(mt.freq))
-    mt = mt.annotate_rows(max_pop_freq=hl.max(mt.freq.map(lambda x: hl.max(x.AF))))
+    mt = mt.annotate_rows(max_pop_freq=hl.max(mt.freq.map(lambda x: x.AF)))
 
     mt = mt.annotate_cols(pop=gnomad_sa[mt.col_key].pop)
     mt = mt.annotate_cols(
         counts=hl.struct(**{
-            f"n_sites_above_{x}": hl.agg.count_where(mt.GT.is_non_ref() & (mt.max_pop_freq > x))
-            for x in frequency_thresholds
+            f"n_sites_above_{key.replace('.', '_')}": hl.agg.count_where(
+                mt.GT.is_non_ref() & (mt.max_pop_freq > threshold)
+            )
+            for threshold, key in zip(frequency_thresholds, threshold_keys, strict=True)
         })
     )
 

--- a/divref/divref/tools/compute_variation_ratios.py
+++ b/divref/divref/tools/compute_variation_ratios.py
@@ -1,0 +1,51 @@
+"""Tool to compute per-sample variant site counts across gnomAD frequency thresholds."""
+
+import hail as hl
+
+from divref.haplotype import HailPath
+
+_FREQ_THRESHOLDS = [0, 0.0001, 0.001, 0.005, 0.01, 0.05, 0.1]
+
+
+def compute_variation_ratios(
+    *,
+    vcfs_path: HailPath,
+    gnomad_va_file: HailPath,
+    gnomad_sa_file: HailPath,
+    output_ht: HailPath,
+) -> None:
+    """
+    Compute per-sample counts of non-reference variant sites across frequency thresholds.
+
+    For each sample and each predefined gnomAD population frequency threshold, counts
+    the number of sites where the sample carries a non-reference genotype. Writes a
+    sample-level Hail table with population labels and per-threshold site counts.
+
+    Args:
+        vcfs_path: Path or glob pattern to input VCF files (GRCh38).
+        gnomad_va_file: Path to the gnomAD variant annotations Hail table
+            (from extract_gnomad_afs).
+        gnomad_sa_file: Path to the gnomAD sample metadata Hail table
+            (from extract_gnomad_afs).
+        output_ht: Output path for the sample-level Hail table.
+    """
+    hl.init()
+
+    gnomad_sa = hl.read_table(gnomad_sa_file)
+    gnomad_va = hl.read_table(gnomad_va_file)
+
+    mt = hl.import_vcf(vcfs_path, reference_genome="GRCh38", min_partitions=64)
+    mt = mt.select_rows().select_cols()
+    mt = mt.annotate_rows(freq=gnomad_va[mt.row_key].pop_freqs)
+    mt = mt.filter_rows(hl.is_defined(mt.freq))
+    mt = mt.annotate_rows(max_pop_freq=hl.max(mt.freq.map(lambda x: hl.max(x.AF))))
+
+    mt = mt.annotate_cols(pop=gnomad_sa[mt.col_key].pop)
+    mt = mt.annotate_cols(
+        counts=hl.struct(**{
+            f"n_sites_above_{x}": hl.agg.count_where(mt.GT.is_non_ref() & (mt.max_pop_freq > x))
+            for x in _FREQ_THRESHOLDS
+        })
+    )
+
+    mt.cols().write(output_ht, overwrite=True)

--- a/divref/divref/tools/compute_variation_ratios.py
+++ b/divref/divref/tools/compute_variation_ratios.py
@@ -2,9 +2,8 @@
 
 import hail as hl
 
+from divref import defaults
 from divref.alias import HailPath
-
-_FREQ_THRESHOLDS = [0, 0.0001, 0.001, 0.005, 0.01, 0.05, 0.1]
 
 
 def compute_variation_ratios(
@@ -13,6 +12,7 @@ def compute_variation_ratios(
     gnomad_va_file: HailPath,
     gnomad_sa_file: HailPath,
     output_ht: HailPath,
+    frequency_thresholds: list[float] = defaults.VARIATION_RATIO_FREQUENCY_THRESHOLDS,
 ) -> None:
     """
     Compute per-sample counts of non-reference variant sites across frequency thresholds.
@@ -28,6 +28,7 @@ def compute_variation_ratios(
         gnomad_sa_file: Path to the gnomAD sample metadata Hail table
             (from extract_gnomad_afs).
         output_ht: Output path for the sample-level Hail table.
+        frequency_thresholds: Frequency thresholds to calculate.
     """
     hl.init()
 
@@ -44,7 +45,7 @@ def compute_variation_ratios(
     mt = mt.annotate_cols(
         counts=hl.struct(**{
             f"n_sites_above_{x}": hl.agg.count_where(mt.GT.is_non_ref() & (mt.max_pop_freq > x))
-            for x in _FREQ_THRESHOLDS
+            for x in frequency_thresholds
         })
     )
 


### PR DESCRIPTION
## Summary

- Ports `compute_variation_ratios.py` from `human-diversity-reference/scripts` as a defopt-compatible toolkit tool
- Counts per-sample non-reference variant sites above each of seven predefined gnomAD population frequency thresholds
- Writes a sample-level Hail table with population labels and counts
- Removes the debug `pprint` call present in the original

## Test plan

- [x] `uv run --directory divref poe check-all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command-line tool to compute variation ratios across predefined frequency thresholds
  * Tool calculates per-sample non-reference variant counts from VCF files using gnomAD reference data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->