### PR TITLE
feat: add remap_divref tool

### DIFF
--- a/divref/divref/main.py
+++ b/divref/divref/main.py
@@ -13,6 +13,7 @@ from divref.tools.create_gnomad_sites_vcf import create_gnomad_sites_vcf
 from divref.tools.extract_gnomad_afs import extract_gnomad_afs
 from divref.tools.extract_sample_metadata import extract_sample_metadata
 from divref.tools.gnomad_hail_table_test_data import gnomad_hail_table_test_data
+from divref.tools.remap_divref import remap_divref
 
 _tools: List[Callable[..., None]] = [
     compute_haplotypes,
@@ -23,6 +24,7 @@ _tools: List[Callable[..., None]] = [
     extract_gnomad_afs,
     extract_sample_metadata,
     gnomad_hail_table_test_data,
+    remap_divref,
 ]
 
 

--- a/divref/divref/tools/remap_divref.py
+++ b/divref/divref/tools/remap_divref.py
@@ -1,0 +1,363 @@
+"""Tool to remap DivRef haplotype coordinates to reference genome coordinates."""
+
+import csv
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+import duckdb
+import pandas as pd
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+from tqdm import tqdm
+
+logger = logging.getLogger(__name__)
+
+
+class Variant(BaseModel):
+    """A genomic variant with chromosome, position, reference, and alternate alleles."""
+
+    chromosome: str
+    position: int
+    reference: str
+    alternate: str
+
+    def render(self) -> str:
+        """
+        Return the variant in colon-delimited format.
+
+        Returns:
+            String in the form chromosome:position:reference:alternate.
+        """
+        return f"{self.chromosome}:{self.position}:{self.reference}:{self.alternate}"
+
+
+class ReferenceMapping(BaseModel):
+    """A mapped interval on the reference genome corresponding to a DivRef haplotype region."""
+
+    chromosome: str
+    start: int
+    end: int
+    variants_involved: list[Variant]
+    first_variant_index: Optional[int]
+    last_variant_index: Optional[int]
+    population_frequencies: dict[str, list[float]]
+
+    def variants_involved_str(self) -> str:
+        """
+        Return a comma-delimited string of all variants involved in this mapping.
+
+        Returns:
+            Comma-separated variant strings in chromosome:position:reference:alternate format.
+        """
+        return ",".join([v.render() for v in self.variants_involved])
+
+
+class Haplotype(BaseModel):
+    """A DivRef haplotype sequence with metadata and population frequency information."""
+
+    # Field names use aliases to match DuckDB column names (which use mixedCase).
+    model_config = ConfigDict(populate_by_name=True)
+
+    sequence_id: str
+    sequence: str
+    sequence_length: int
+    n_variants: int
+    fraction_phased: float
+    popmax_empirical_af: float = Field(alias="popmax_empirical_AF")
+    popmax_empirical_ac: int = Field(alias="popmax_empirical_AC")
+    estimated_gnomad_af: float = Field(alias="estimated_gnomad_AF")
+    max_pop: str
+    variants: str
+    source: str
+    gnomad_af_afr: str = Field(alias="gnomAD_AF_afr")
+    gnomad_af_amr: str = Field(alias="gnomAD_AF_amr")
+    gnomad_af_eas: str = Field(alias="gnomAD_AF_eas")
+    gnomad_af_nfe: str = Field(alias="gnomAD_AF_nfe")
+    gnomad_af_sas: str = Field(alias="gnomAD_AF_sas")
+
+    _variants: Optional[list[Variant]] = None
+
+    def parsed_variants(self) -> list[Variant]:
+        """
+        Parse the comma-delimited variants string into Variant objects.
+
+        Returns:
+            List of Variant objects parsed from the variants field.
+        """
+        if self._variants is not None:
+            return self._variants
+        vs = []
+        for v_str in self.variants.split(","):
+            chrom, pos, ref, alt = v_str.strip().split(":")
+            vs.append(Variant(chromosome=chrom, position=int(pos), reference=ref, alternate=alt))
+        self._variants = vs
+        return vs
+
+    def contig(self) -> str:
+        """
+        Return the chromosome of the first variant in this haplotype.
+
+        Returns:
+            Chromosome name (e.g. 'chr1').
+        """
+        return self.parsed_variants()[0].chromosome
+
+    def reference_mapping(self, start: int, end: int, context_size: int) -> ReferenceMapping:
+        """
+        Map a [start, end) interval in haplotype sequence space to reference genome coordinates.
+
+        Accounts for insertions and deletions when translating coordinates. For positions
+        within a variant interval, snaps to the variant boundary (start for the left edge,
+        end for the right edge). For positions in reference-only sequence, translates
+        relative to the nearest preceding variant.
+
+        Args:
+            start: Start position (0-indexed, inclusive) in haplotype sequence space.
+            end: End position (0-indexed, exclusive) in haplotype sequence space.
+            context_size: Number of flanking reference bases prepended to the haplotype sequence.
+
+        Returns:
+            ReferenceMapping with the corresponding reference genome interval and variant metadata.
+        """
+        vs = self.parsed_variants()
+
+        # Build [start, end) intervals in 0-indexed haplotype sequence space for each variant.
+        # index_translation converts locus positions to string indices: locus - translation = index.
+        variant_intervals: list[tuple[int, int]] = []
+        index_translation = vs[0].position - context_size
+        for v in vs:
+            v_start = v.position - index_translation
+            v_end = v_start + len(v.alternate)
+            index_translation += len(v.reference) - len(v.alternate)
+            variant_intervals.append((v_start, v_end))
+
+        first_variant_index: Optional[int] = None
+        last_variant_index: Optional[int] = None
+        for i, (v_start, v_end) in enumerate(variant_intervals):
+            if _intervals_overlap(start, end, v_start, v_end):
+                if first_variant_index is None:
+                    first_variant_index = i
+                last_variant_index = i
+
+        reference_coord_start = _translate_coordinate_to_ref(start, -1, vs, variant_intervals)
+        reference_coord_end = _translate_coordinate_to_ref(end, 1, vs, variant_intervals)
+
+        all_pop_freqs = {
+            "afr": _parse_pop_freqs(self.gnomad_af_afr),
+            "amr": _parse_pop_freqs(self.gnomad_af_amr),
+            "eas": _parse_pop_freqs(self.gnomad_af_eas),
+            "nfe": _parse_pop_freqs(self.gnomad_af_nfe),
+            "sas": _parse_pop_freqs(self.gnomad_af_sas),
+        }
+
+        if first_variant_index is not None and last_variant_index is not None:
+            variants_involved = vs[first_variant_index : last_variant_index + 1]
+        else:
+            variants_involved = []
+
+        return ReferenceMapping(
+            chromosome=self.contig(),
+            start=reference_coord_start,
+            end=reference_coord_end,
+            variants_involved=variants_involved,
+            first_variant_index=first_variant_index,
+            last_variant_index=last_variant_index,
+            population_frequencies=all_pop_freqs,
+        )
+
+
+def _intervals_overlap(start1: int, end1: int, start2: int, end2: int) -> bool:
+    return start1 < end2 and start2 < end1
+
+
+def _parse_pop_freqs(encoded: str) -> list[float]:
+    return [0.0 if v == "null" else float(v) for v in encoded.split(",")]
+
+
+def _translate_coordinate_to_ref(
+    coord: int,
+    sign: int,
+    vs: list[Variant],
+    variant_intervals: list[tuple[int, int]],
+) -> int:
+    """
+    Translate a haplotype sequence coordinate back to a reference genome position.
+
+    If the coordinate falls before the first variant, it is translated relative to
+    that variant's reference position. If it falls within a variant interval, it snaps
+    to the variant's reference start (sign < 0) or end (sign > 0). Otherwise it is
+    translated relative to the end of the last preceding variant on the reference.
+
+    Args:
+        coord: 0-indexed coordinate in haplotype sequence space.
+        sign: Negative to snap to variant start, positive to snap to variant end.
+        vs: List of Variant objects in order.
+        variant_intervals: Corresponding [start, end) intervals in haplotype sequence space.
+
+    Returns:
+        Reference genome position (1-based locus coordinate).
+    """
+    first_variant_start = variant_intervals[0][0]
+    if coord < first_variant_start:
+        return vs[0].position - (first_variant_start - coord)
+
+    last_smaller_variant = 0
+    for i, (v_start, v_end) in enumerate(variant_intervals):
+        if v_start <= coord < v_end:
+            if sign < 0:
+                return vs[i].position
+            else:
+                return vs[i].position + len(vs[i].reference)
+        if v_start > coord:
+            break
+        last_smaller_variant = i
+
+    v = vs[last_smaller_variant]
+    v_end_ref = v.position + len(v.reference)
+    return v_end_ref + (coord - variant_intervals[last_smaller_variant][1])
+
+
+def _get_index_connection(index_path: Optional[Path]) -> duckdb.DuckDBPyConnection:
+    if index_path is None:
+        for root, _dirs, files in os.walk(Path(__file__).parent):
+            for file in files:
+                if file.endswith(".duckdb"):
+                    index_path = Path(root) / file
+                    break
+    if index_path is None:
+        raise RuntimeError(
+            "Unable to find a DuckDB index file. Pass --index-path or run from the "
+            "same directory as the index file."
+        )
+    return duckdb.connect(str(index_path))
+
+
+def remap_divref(
+    *,
+    input_path: Path,
+    output_path: Path,
+    index_path: Optional[Path] = None,
+    separator: str = "\t",
+    batch_size: int = 25000,
+) -> None:
+    """
+    Remap DivRef haplotype coordinates to reference genome coordinates for CALITAS output.
+
+    Reads a CALITAS output TSV, looks up each haplotype sequence in the DivRef DuckDB
+    index, translates the haplotype-space coordinates back to reference genome positions,
+    and writes an augmented TSV with reference coordinates and variant metadata appended.
+
+    Args:
+        input_path: Path to the CALITAS output file.
+        output_path: Path to write the remapped output file.
+        index_path: Path to the DivRef DuckDB index file. If not provided, the tool
+            searches the directory containing this script for a .duckdb file.
+        separator: Field delimiter used in both input and output files.
+        batch_size: Number of rows to process per database query batch.
+    """
+    conn = _get_index_connection(index_path)
+
+    df = pd.read_csv(input_path, sep=separator)
+    chrom_field = "chromosome"
+    start_field = "coordinate_start"
+    end_field = "coordinate_end"
+
+    if not all(x in df.columns for x in (chrom_field, start_field, end_field)):
+        raise ValueError(
+            f"Required fields not found in input file: {chrom_field}, {start_field}, {end_field}"
+        )
+
+    if df[chrom_field].dtype != object:
+        df[chrom_field] = df[chrom_field].astype(str)
+
+    version: str = conn.execute("SELECT * FROM VERSION").fetchone()[0]  # type: ignore[index]
+    window_size: int = conn.execute("SELECT * FROM window_size").fetchone()[0]  # type: ignore[index]
+
+    contigs: list[str] = []
+    starts: list[int] = []
+    ends: list[int] = []
+    variants_involved: list[str] = []
+    all_variants: list[str] = []
+    n_variants_involved: list[int] = []
+    popmax_empirical_af: list[float] = []
+    popmax_empirical_ac: list[int] = []
+    max_pop: list[str] = []
+    all_pop_freqs_json: list[str] = []
+    source: list[str] = []
+
+    for batch_start in tqdm(range(0, len(df), batch_size)):
+        batch_end = min(batch_start + batch_size, len(df))
+        batch_df = df.iloc[batch_start:batch_end]
+        batch_hap_ids = batch_df[chrom_field].tolist()
+
+        results = conn.execute(
+            """
+            SELECT * FROM sequences
+            WHERE sequences.sequence_id IN (SELECT unnest($1::STRING[]))
+            """,
+            [batch_hap_ids],
+        ).fetchall()
+
+        columns = [desc[0] for desc in conn.description]
+        id_to_hap: dict[str, Haplotype] = {}
+        for row in results:
+            hap = Haplotype(**dict(zip(columns, row, strict=True)))
+            id_to_hap[hap.sequence_id] = hap
+
+        for _, df_row in batch_df.iterrows():
+            start: int = df_row[start_field]
+            end: int = df_row[end_field]
+            hap_id: str = df_row[chrom_field]
+
+            strand: str = df_row["strand"]
+            padded_target: str = df_row["padded_target"]
+            target: str = df_row["unpadded_target_sequence"]
+
+            padded_len_adj = len(padded_target) - len(target)
+            if strand == "+":
+                end += padded_len_adj
+            else:
+                start -= padded_len_adj
+
+            found_hap = id_to_hap.get(hap_id)
+            if found_hap is None:
+                raise RuntimeError(
+                    f"Unable to find haplotype for {hap_id} — ensure you are aligning against "
+                    f"the same DivRef version as this index (DivRef-v{version})"
+                )
+            rm = found_hap.reference_mapping(start, end, window_size)
+
+            contigs.append(rm.chromosome)
+            starts.append(rm.start)
+            ends.append(rm.end)
+            all_variants.append(found_hap.variants)
+            variants_involved.append(rm.variants_involved_str())
+            n_variants_involved.append(len(rm.variants_involved))
+            popmax_empirical_af.append(found_hap.popmax_empirical_af)
+            popmax_empirical_ac.append(found_hap.popmax_empirical_ac)
+            max_pop.append(found_hap.max_pop)
+            source.append(found_hap.source)
+            all_pop_freqs_json.append(json.dumps(rm.population_frequencies).replace(" ", ""))
+
+    df["divref_sequence_id"] = df[chrom_field]
+    df["divref_start"] = df[start_field]
+    df["divref_end"] = df[end_field]
+    df[chrom_field] = contigs
+    df[start_field] = starts
+    df[end_field] = ends
+    df["genome_build"] = f"DivRef-v{version}"
+    df["all_variants"] = all_variants
+    df["variants_involved"] = variants_involved
+    df["n_variants_involved"] = n_variants_involved
+    df["popmax_empirical_AF"] = popmax_empirical_af
+    df["popmax_empirical_AC"] = popmax_empirical_ac
+    df["max_pop"] = max_pop
+    df["variant_source"] = source
+    df["population_frequencies_json"] = all_pop_freqs_json
+
+    df.to_csv(output_path, sep=separator, index=False, quoting=csv.QUOTE_NONE)
+    logger.info("Wrote remapped output to %s", output_path)

--- a/divref/divref/tools/remap_divref.py
+++ b/divref/divref/tools/remap_divref.py
@@ -263,19 +263,22 @@ def remap_divref(
     """
     conn = _get_index_connection(index_path)
 
-    df = pd.read_csv(input_path, sep=separator)
-    chrom_field = "chromosome"
-    start_field = "coordinate_start"
-    end_field = "coordinate_end"
+    df: pd.DataFrame = pd.read_csv(input_path, sep=separator)
+    chrom_field: str = "chromosome"
+    start_field: str = "coordinate_start"
+    end_field: str = "coordinate_end"
+    strand_field: str = "strand"
+    padded_target_field: str = "padded_target"
+    unpadded_target_field: str = "unpadded_target_sequence"
 
-    required_fields = (
+    required_fields: list[str] = [
         chrom_field,
         start_field,
         end_field,
-        "strand",
-        "padded_target",
-        "unpadded_target_sequence",
-    )
+        strand_field,
+        padded_target_field,
+        unpadded_target_field,
+    ]
     if not all(x in df.columns for x in required_fields):
         raise ValueError(f"Required fields not found in input file: {', '.join(required_fields)}")
 
@@ -329,10 +332,9 @@ def remap_divref(
             start: int = df_row[start_field]
             end: int = df_row[end_field]
             hap_id: str = df_row[chrom_field]
-
-            strand: str = df_row["strand"]
-            padded_target: str = df_row["padded_target"]
-            target: str = df_row["unpadded_target_sequence"]
+            strand: str = df_row[strand_field]
+            padded_target: str = df_row[padded_target_field]
+            target: str = df_row[unpadded_target_field]
 
             padded_len_adj = len(padded_target.replace("-", "")) - len(target)
             if strand == "+":

--- a/divref/divref/tools/remap_divref.py
+++ b/divref/divref/tools/remap_divref.py
@@ -225,7 +225,7 @@ def _translate_coordinate_to_ref(
 
 def _get_index_connection(index_path: Optional[Path]) -> duckdb.DuckDBPyConnection:
     if index_path is None:
-        for root, _dirs, files in os.walk(Path(__file__).parent):
+        for root, _dirs, files in os.walk(Path.cwd()):
             for file in files:
                 if file.endswith(".duckdb"):
                     index_path = Path(root) / file
@@ -268,16 +268,31 @@ def remap_divref(
     start_field = "coordinate_start"
     end_field = "coordinate_end"
 
-    if not all(x in df.columns for x in (chrom_field, start_field, end_field)):
-        raise ValueError(
-            f"Required fields not found in input file: {chrom_field}, {start_field}, {end_field}"
-        )
+    required_fields = (
+        chrom_field,
+        start_field,
+        end_field,
+        "strand",
+        "padded_target",
+        "unpadded_target_sequence",
+    )
+    if not all(x in df.columns for x in required_fields):
+        raise ValueError(f"Required fields not found in input file: {', '.join(required_fields)}")
 
     if df[chrom_field].dtype != object:
         df[chrom_field] = df[chrom_field].astype(str)
 
-    version: str = conn.execute("SELECT * FROM VERSION").fetchone()[0]  # type: ignore[index]
-    window_size: int = conn.execute("SELECT * FROM window_size").fetchone()[0]  # type: ignore[index]
+    version_row = conn.execute("SELECT * FROM VERSION").fetchone()
+    if version_row is None:
+        raise RuntimeError("Index is missing VERSION table — ensure this is a valid DivRef index.")
+    version: str = version_row[0]
+
+    window_size_row = conn.execute("SELECT * FROM window_size").fetchone()
+    if window_size_row is None:
+        raise RuntimeError(
+            "Index is missing window_size table — ensure this is a valid DivRef index."
+        )
+    window_size: int = window_size_row[0]
 
     contigs: list[str] = []
     starts: list[int] = []
@@ -361,5 +376,5 @@ def remap_divref(
     df["variant_source"] = source
     df["population_frequencies_json"] = all_pop_freqs_json
 
-    df.to_csv(output_path, sep=separator, index=False, quoting=csv.QUOTE_NONE)
+    df.to_csv(output_path, sep=separator, index=False, quoting=csv.QUOTE_MINIMAL)
     logger.info("Wrote remapped output to %s", output_path)

--- a/divref/divref/tools/remap_divref.py
+++ b/divref/divref/tools/remap_divref.py
@@ -202,7 +202,9 @@ def _translate_coordinate_to_ref(
         Reference genome position (1-based locus coordinate).
     """
     first_variant_start = variant_intervals[0][0]
-    if coord < first_variant_start:
+    if (coord < first_variant_start and sign == -1) or (
+        coord - 1 < first_variant_start and sign == 1
+    ):
         return vs[0].position - (first_variant_start - coord)
 
     last_smaller_variant = 0
@@ -317,7 +319,7 @@ def remap_divref(
             padded_target: str = df_row["padded_target"]
             target: str = df_row["unpadded_target_sequence"]
 
-            padded_len_adj = len(padded_target) - len(target)
+            padded_len_adj = len(padded_target.replace("-", "")) - len(target)
             if strand == "+":
                 end += padded_len_adj
             else:

--- a/divref/pyproject.toml
+++ b/divref/pyproject.toml
@@ -114,7 +114,7 @@ module = "defopt"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = ["hail", "hail.*", "tqdm", "tqdm.*"]
+module = ["hail", "hail.*", "pandas", "pandas.*", "tqdm", "tqdm.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/divref/tests/tools/test_remap_divref.py
+++ b/divref/tests/tools/test_remap_divref.py
@@ -1,0 +1,158 @@
+"""Tests for Haplotype.reference_mapping coordinate translation in remap_divref."""
+
+from typing import Any
+
+from divref.tools.remap_divref import Haplotype
+from divref.tools.remap_divref import ReferenceMapping
+
+
+def create_haplotype(
+    sequence_id: str = "test_hap",
+    sequence: str = "ACGT",
+    sequence_length: int = 4,
+    n_variants: int = 3,
+    variants: str = "1:500:A:T,1:505:C:G,1:510:T:A",
+    gnomAD_AF_afr: str = "0.1,0.2,0.3",  # noqa: N803
+    gnomAD_AF_amr: str = "0.15,0.25,0.35",  # noqa: N803
+    gnomAD_AF_eas: str = "0.12,0.22,0.32",  # noqa: N803
+    gnomAD_AF_nfe: str = "0.11,0.21,0.31",  # noqa: N803
+    gnomAD_AF_sas: str = "0.13,0.23,0.33",  # noqa: N803
+    **kwargs: Any,
+) -> Haplotype:
+    """
+    Create a Haplotype instance with sensible defaults for testing.
+
+    Args:
+        sequence_id: Haplotype sequence identifier.
+        sequence: Haplotype sequence string.
+        sequence_length: Length of the sequence.
+        n_variants: Number of variants in the haplotype.
+        variants: Comma-separated variant strings (chrom:pos:ref:alt).
+        gnomAD_AF_afr: Comma-separated AFR allele frequencies per variant.
+        gnomAD_AF_amr: Comma-separated AMR allele frequencies per variant.
+        gnomAD_AF_eas: Comma-separated EAS allele frequencies per variant.
+        gnomAD_AF_nfe: Comma-separated NFE allele frequencies per variant.
+        gnomAD_AF_sas: Comma-separated SAS allele frequencies per variant.
+        **kwargs: Additional fields passed to Haplotype.
+
+    Returns:
+        A Haplotype instance for use in tests.
+    """
+    defaults: dict[str, Any] = {
+        "fraction_phased": 1.0,
+        "popmax_empirical_AF": 0.25,
+        "popmax_empirical_AC": 1000,
+        "estimated_gnomad_AF": 0.15,
+        "max_pop": "amr",
+        "source": "test_source",
+    }
+    defaults.update(kwargs)
+    return Haplotype(
+        sequence_id=sequence_id,
+        sequence=sequence,
+        sequence_length=sequence_length,
+        n_variants=n_variants,
+        variants=variants,
+        gnomAD_AF_afr=gnomAD_AF_afr,
+        gnomAD_AF_amr=gnomAD_AF_amr,
+        gnomAD_AF_eas=gnomAD_AF_eas,
+        gnomAD_AF_nfe=gnomAD_AF_nfe,
+        gnomAD_AF_sas=gnomAD_AF_sas,
+        **defaults,
+    )
+
+
+def test_basic_snp_variants_involved() -> None:
+    # With context_size=10, haplotype sequence pos 0 = reference pos 490.
+    # Variants at ref positions 500, 505, 510 map to haplotype positions 10, 15, 20.
+    # Query window [12, 17) overlaps only the second variant (pos 15..16).
+    haplotype = create_haplotype(sequence_id="hap1", variants="1:500:A:T,1:505:C:G,1:510:T:A")
+    rm: ReferenceMapping = haplotype.reference_mapping(12, 17, 10)
+
+    assert rm.first_variant_index == 1
+    assert rm.last_variant_index == 1
+    assert rm.population_frequencies == {
+        "afr": [0.1, 0.2, 0.3],
+        "amr": [0.15, 0.25, 0.35],
+        "eas": [0.12, 0.22, 0.32],
+        "nfe": [0.11, 0.21, 0.31],
+        "sas": [0.13, 0.23, 0.33],
+    }
+
+
+def test_deletion_shifts_coordinates() -> None:
+    # Second variant is a deletion (CC→G), which shifts subsequent haplotype positions.
+    # Query [14, 20) spans the deletion and the following SNP.
+    haplotype = create_haplotype(sequence_id="hap2", variants="1:500:A:T,1:505:CC:G,1:510:T:A")
+    rm = haplotype.reference_mapping(14, 20, 10)
+
+    assert rm.first_variant_index == 1
+    assert rm.last_variant_index == 2
+
+
+def test_insertion_shifts_coordinates() -> None:
+    # First variant is an insertion (T→TTT), which shifts subsequent haplotype positions.
+    # Query [15, 18) lands in the expanded haplotype space after the insertion.
+    haplotype = create_haplotype(sequence_id="hap3", variants="1:500:T:TTT,1:505:C:G,1:510:T:A")
+    rm = haplotype.reference_mapping(15, 18, 10)
+
+    assert rm.first_variant_index == 1
+    assert rm.last_variant_index == 1
+
+
+def test_no_variants_in_range() -> None:
+    # Query [0, 5) is entirely in the flanking context before any variant.
+    haplotype = create_haplotype(sequence_id="hap4", variants="1:500:A:T,1:510:C:G")
+    rm = haplotype.reference_mapping(0, 5, 10)
+
+    assert rm.first_variant_index is None
+    assert rm.last_variant_index is None
+
+
+def test_complex_multi_indel_mapping() -> None:
+    # Three variants: deletion, insertion, deletion. Query [9, 22) spans all three.
+    haplotype = create_haplotype(
+        sequence_id="hap5",
+        variants="1:500:AT:A,1:505:C:CTT,1:510:GGG:T",
+        gnomAD_AF_afr="0.05,0.15,0.25",
+        gnomAD_AF_amr="0.06,0.16,0.26",
+        gnomAD_AF_eas="0.07,0.17,0.27",
+        gnomAD_AF_nfe="0.04,0.14,0.24",
+        gnomAD_AF_sas="0.03,0.13,0.23",
+    )
+    rm = haplotype.reference_mapping(9, 22, 10)
+
+    assert rm.first_variant_index == 0
+    assert rm.last_variant_index == 2
+
+
+def test_large_insertion_with_null_frequencies() -> None:
+    # Single large insertion. null gnomAD frequencies should be parsed as 0.0.
+    # context_size=25, variant at ref pos 90349349.
+    # Query [22, 42) starts before the insertion (ref start = 90349349 - 3 = 90349346).
+    alt = "TATGCAAGTGTCATCAGATGAATTGATGACATTTTTGTCAAGTTTAAGCACTGAAAGAACAAACCTCTAAATC"
+    haplotype = create_haplotype(
+        sequence_id="hap6",
+        sequence="ACTACTATCTATATCATCTACTACTACTATCATCATCATCAT",
+        sequence_length=42,
+        n_variants=1,
+        variants=f"chr12:90349349:T:{alt}",
+        gnomAD_AF_afr="null",
+        gnomAD_AF_amr="null",
+        gnomAD_AF_eas="null",
+        gnomAD_AF_nfe="null",
+        gnomAD_AF_sas="null",
+    )
+    rm = haplotype.reference_mapping(22, 42, 25)
+
+    assert rm.first_variant_index == 0
+    assert rm.last_variant_index == 0
+    assert rm.start == 90349346
+    assert rm.end == 90349350
+    assert rm.population_frequencies == {
+        "afr": [0.0],
+        "amr": [0.0],
+        "eas": [0.0],
+        "nfe": [0.0],
+        "sas": [0.0],
+    }

--- a/pixi.lock
+++ b/pixi.lock
@@ -85,14 +85,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.4-h6548e54_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.11.0-6_h6ae95b6_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.32-pthreads_h94d23a6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
@@ -108,7 +108,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjdk-11.0.30-ha668962_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
@@ -129,7 +129,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/reretry-0.11.8-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.5.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.6.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/bioconda/noarch/snakefmt-1.0.0-pyh7a41576_1.conda
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.20.0-pyhdfd78af_0.tar.bz2
@@ -175,8 +175,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8c/24/33da34950a637df9bca4bac4b99be81e060613edf22a54589d17e2b7b51a/azure_mgmt_storage-20.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d8/3a/6ef2047a072e54e1142718d433d50e9514c999a58f51abfff7902f3a72f8/azure_storage_blob-12.28.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/5d/e96520996607c9b894a4716ddedc447a68351b0a8729f26ac012c8e7041b/bokeh-3.4.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3b/52/69ebde82ce8b47cdee52b2450b2cbf1b3b107e192a3223bf88a567373d85/boto3-1.42.87-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/1f/94e1b020fd87b52f092fdd111d9800f2411dc113a0957d0d85b7d2c7f247/botocore-1.42.87-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/bd/a0c5011a8eddce39a9b613b13a75057bf960ef2145ff4d1583ed81a2599b/boto3-1.42.90-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fc/1e/44afcdc3b526b6e1569dd142083c6ed1cb8b92b4141de1c78ded883b449a/botocore-1.42.90-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b1/92/dfd892312d822f36c55366118b95d914e5f16de11044a27cf10a7d71bbbf/commonmark-0.9.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
@@ -185,11 +185,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/cc/3f/3baf4e6fed12dac76c0ccb4716fd4235ef0aa5b48f66aab6f970afc7b44e/defopt-6.4.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/6f/d6/8f9a6b1fbcc669108ec6a4d625a70be9e480b437ed9b70cd56b78cd577a6/duckdb-1.5.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/26/78/eb1e064ea8b9df3b87b167bfd7a407b2f615a4291e06cba756727adfa06c/duckdb-1.5.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/0e/bfc3d7de5d1788871d1be3e6862fe3e56d92b446909b7b032c373fc4ecab/google_auth_oauthlib-0.8.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/53/8a/5b1a62458e862c86a66bafaa63f5e27268bbf47a726b9161be16c25605c0/hail-0.2.137-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b0/95/1aeb6cc7c4fd0f61088315a9056e37f4d2faa5316051eabb55b4ec602265/hail-0.2.138-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/7b/bca5613a0c3b542420cf92bd5e5fb8ebd5435ce1011a091f66bb7693285e/humanize-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/84/7bfe436fa6a4943eecb17c2cca9c84215299684575376d664ea6bf294439/janus-1.0.0-py3-none-any.whl
@@ -216,8 +216,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/d0/c67967a10abd89529cb9aded9d73f43e5de00cf21243638ef529f6757262/pycares-5.0.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/81/5a/2225f4c176dbfed0d809e848b50ef08f70e61daa667b7fa14b0d311ae44d/pydantic-2.13.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/a3/09d929a40e6727274b0b500ad06e1b3f35d4f4665ae1c8ba65acbb17e9b5/pydantic_core-2.46.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/5a/3806f44eb47387e8af803508cdd6bbc0df784febf4dc010700be04a1ff89/pyspark-3.5.8.tar.gz
@@ -229,6 +229,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/32/60/81ac2e7d1e3b861ab478a72e3b20fc91c4302acd2274822e493758941829/rich-12.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
@@ -312,7 +313,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openjdk-11.0.30-h48c29e7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/perl-5.32.1-7_h10d778d_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
@@ -330,7 +331,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/reretry-0.11.8-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.30.0-py312h8a6388b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.5.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.6.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/bioconda/noarch/snakefmt-1.0.0-pyh7a41576_1.conda
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.20.0-pyhdfd78af_0.tar.bz2
@@ -364,8 +365,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8c/24/33da34950a637df9bca4bac4b99be81e060613edf22a54589d17e2b7b51a/azure_mgmt_storage-20.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d8/3a/6ef2047a072e54e1142718d433d50e9514c999a58f51abfff7902f3a72f8/azure_storage_blob-12.28.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/5d/e96520996607c9b894a4716ddedc447a68351b0a8729f26ac012c8e7041b/bokeh-3.4.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3b/52/69ebde82ce8b47cdee52b2450b2cbf1b3b107e192a3223bf88a567373d85/boto3-1.42.87-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/1f/94e1b020fd87b52f092fdd111d9800f2411dc113a0957d0d85b7d2c7f247/botocore-1.42.87-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/bd/a0c5011a8eddce39a9b613b13a75057bf960ef2145ff4d1583ed81a2599b/boto3-1.42.90-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fc/1e/44afcdc3b526b6e1569dd142083c6ed1cb8b92b4141de1c78ded883b449a/botocore-1.42.90-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b1/92/dfd892312d822f36c55366118b95d914e5f16de11044a27cf10a7d71bbbf/commonmark-0.9.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/45/adfee365d9ea3d853550b2e735f9d66366701c65db7855cd07621732ccfc/contourpy-1.3.3-cp312-cp312-macosx_10_13_x86_64.whl
@@ -374,11 +375,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/cc/3f/3baf4e6fed12dac76c0ccb4716fd4235ef0aa5b48f66aab6f970afc7b44e/defopt-6.4.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/44/03/1794dcdda75ff203ab0982ff7eb5232549b58b9af66f243f1b7212d6d6be/duckdb-1.5.1-cp312-cp312-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/2d/8a/3e25b5d03bcf1fb99d189912f8ce92b1db4f9c8778e1b1f55745973a855a/duckdb-1.5.2-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/64/80/4f6e318ee2a7c0750ed724fa33a4bdf1eacdc5a39a7a24e818a773cd91af/frozenlist-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/0e/bfc3d7de5d1788871d1be3e6862fe3e56d92b446909b7b032c373fc4ecab/google_auth_oauthlib-0.8.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/53/8a/5b1a62458e862c86a66bafaa63f5e27268bbf47a726b9161be16c25605c0/hail-0.2.137-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b0/95/1aeb6cc7c4fd0f61088315a9056e37f4d2faa5316051eabb55b4ec602265/hail-0.2.138-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/7b/bca5613a0c3b542420cf92bd5e5fb8ebd5435ce1011a091f66bb7693285e/humanize-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/84/7bfe436fa6a4943eecb17c2cca9c84215299684575376d664ea6bf294439/janus-1.0.0-py3-none-any.whl
@@ -405,8 +406,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/67/e84ba11d3fec3bf1322c3b302c4df13c85e0a1bc48f16d65cd0f59ad9853/pycares-5.0.1-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/81/5a/2225f4c176dbfed0d809e848b50ef08f70e61daa667b7fa14b0d311ae44d/pydantic-2.13.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ce/fb/caaa8ee23861c170f07dbd58fc2be3a2c02a32637693cbb23eef02e84808/pydantic_core-2.46.1-cp312-cp312-macosx_10_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/5a/3806f44eb47387e8af803508cdd6bbc0df784febf4dc010700be04a1ff89/pyspark-3.5.8.tar.gz
@@ -418,6 +419,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/32/60/81ac2e7d1e3b861ab478a72e3b20fc91c4302acd2274822e493758941829/rich-12.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
@@ -500,7 +502,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjdk-11.0.30-h258754b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/perl-5.32.1-7_h4614cfb_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
@@ -518,7 +520,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/reretry-0.11.8-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.30.0-py312h6ef9ec0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.5.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.6.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/bioconda/noarch/snakefmt-1.0.0-pyh7a41576_1.conda
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.20.0-pyhdfd78af_0.tar.bz2
@@ -552,8 +554,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8c/24/33da34950a637df9bca4bac4b99be81e060613edf22a54589d17e2b7b51a/azure_mgmt_storage-20.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d8/3a/6ef2047a072e54e1142718d433d50e9514c999a58f51abfff7902f3a72f8/azure_storage_blob-12.28.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/5d/e96520996607c9b894a4716ddedc447a68351b0a8729f26ac012c8e7041b/bokeh-3.4.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3b/52/69ebde82ce8b47cdee52b2450b2cbf1b3b107e192a3223bf88a567373d85/boto3-1.42.87-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/1f/94e1b020fd87b52f092fdd111d9800f2411dc113a0957d0d85b7d2c7f247/botocore-1.42.87-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/bd/a0c5011a8eddce39a9b613b13a75057bf960ef2145ff4d1583ed81a2599b/boto3-1.42.90-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fc/1e/44afcdc3b526b6e1569dd142083c6ed1cb8b92b4141de1c78ded883b449a/botocore-1.42.90-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b1/92/dfd892312d822f36c55366118b95d914e5f16de11044a27cf10a7d71bbbf/commonmark-0.9.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/3e/405b59cfa13021a56bba395a6b3aca8cec012b45bf177b0eaf7a202cde2c/contourpy-1.3.3-cp312-cp312-macosx_11_0_arm64.whl
@@ -562,11 +564,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/cc/3f/3baf4e6fed12dac76c0ccb4716fd4235ef0aa5b48f66aab6f970afc7b44e/defopt-6.4.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/87/03/293bccd838a293d42ea26dec7f4eb4f58b57b6c9ffcfabc6518a5f20a24a/duckdb-1.5.1-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/19/bb/58001f0815002b1a93431bf907f77854085c7d049b83d521814a07b9db0b/duckdb-1.5.2-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/2b/94/5c8a2b50a496b11dd519f4a24cb5496cf125681dd99e94c604ccdea9419a/frozenlist-1.8.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/0e/bfc3d7de5d1788871d1be3e6862fe3e56d92b446909b7b032c373fc4ecab/google_auth_oauthlib-0.8.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/53/8a/5b1a62458e862c86a66bafaa63f5e27268bbf47a726b9161be16c25605c0/hail-0.2.137-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b0/95/1aeb6cc7c4fd0f61088315a9056e37f4d2faa5316051eabb55b4ec602265/hail-0.2.138-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/7b/bca5613a0c3b542420cf92bd5e5fb8ebd5435ce1011a091f66bb7693285e/humanize-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/84/7bfe436fa6a4943eecb17c2cca9c84215299684575376d664ea6bf294439/janus-1.0.0-py3-none-any.whl
@@ -593,8 +595,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/ae/50fbb3b4e52b9f1d16a36ffabd051ef8b2106b3f0a0d1c1113904d187a9d/pycares-5.0.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/81/5a/2225f4c176dbfed0d809e848b50ef08f70e61daa667b7fa14b0d311ae44d/pydantic-2.13.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fa/61/bcffaa52894489ff89e5e1cdde67429914bf083c0db7296bef153020f786/pydantic_core-2.46.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/5a/3806f44eb47387e8af803508cdd6bbc0df784febf4dc010700be04a1ff89/pyspark-3.5.8.tar.gz
@@ -606,6 +608,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/32/60/81ac2e7d1e3b861ab478a72e3b20fc91c4302acd2274822e493758941829/rich-12.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
@@ -973,20 +976,20 @@ packages:
   - tornado>=6.2
   - xyzservices>=2021.9.1
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/3b/52/69ebde82ce8b47cdee52b2450b2cbf1b3b107e192a3223bf88a567373d85/boto3-1.42.87-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/e1/bd/a0c5011a8eddce39a9b613b13a75057bf960ef2145ff4d1583ed81a2599b/boto3-1.42.90-py3-none-any.whl
   name: boto3
-  version: 1.42.87
-  sha256: 15cc1404b3ccbcfe17bd5834d467b1b28d53d9aca44e3798dc44876ac57362e6
+  version: 1.42.90
+  sha256: fde7f7bcad6ec8342d6bf18f56d118d0cb6df189310cfaf73e2eb6443b1cb418
   requires_dist:
-  - botocore>=1.42.87,<1.43.0
+  - botocore>=1.42.90,<1.43.0
   - jmespath>=0.7.1,<2.0.0
   - s3transfer>=0.16.0,<0.17.0
   - botocore[crt]>=1.21.0,<2.0a0 ; extra == 'crt'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/ec/1f/94e1b020fd87b52f092fdd111d9800f2411dc113a0957d0d85b7d2c7f247/botocore-1.42.87-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/fc/1e/44afcdc3b526b6e1569dd142083c6ed1cb8b92b4141de1c78ded883b449a/botocore-1.42.90-py3-none-any.whl
   name: botocore
-  version: 1.42.87
-  sha256: 32832df27c039cc1a518289afe0f6006296d3df26603b5f66e911457e67f0146
+  version: 1.42.90
+  sha256: 5c95504720346990adc8e3ae1023eb46f9409084b79688e4773ba7099c5fd3db
   requires_dist:
   - jmespath>=0.7.1,<2.0.0
   - python-dateutil>=2.1,<3.0.0
@@ -1762,7 +1765,7 @@ packages:
 - pypi: ./divref
   name: divref
   version: 0.1.0
-  sha256: 78f898ba19df770834363cd89b9cd805a1a3a9cc3086153f9e8515c9e6a13c37
+  sha256: 0f38e966179a65bbeb9bf8356d6c3f6cab4e64bddbc31ae5feb5eb88b4b80e2e
   requires_dist:
   - defopt~=6.4
   - duckdb>=1.0
@@ -1793,10 +1796,10 @@ packages:
   - pkg:pypi/dpath?source=hash-mapping
   size: 21853
   timestamp: 1762165431693
-- pypi: https://files.pythonhosted.org/packages/44/03/1794dcdda75ff203ab0982ff7eb5232549b58b9af66f243f1b7212d6d6be/duckdb-1.5.1-cp312-cp312-macosx_10_13_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/19/bb/58001f0815002b1a93431bf907f77854085c7d049b83d521814a07b9db0b/duckdb-1.5.2-cp312-cp312-macosx_11_0_arm64.whl
   name: duckdb
-  version: 1.5.1
-  sha256: 0a6acc2040bec1f05de62a2f3f68f4c12f3ec7d6012b4317d0ab1a195af26225
+  version: 1.5.2
+  sha256: 2a1de4f4d454b8c97aec546c82003fc834d3422ce4bc6a19902f3462ef293bed
   requires_dist:
   - ipython ; extra == 'all'
   - fsspec ; extra == 'all'
@@ -1805,10 +1808,10 @@ packages:
   - pyarrow ; extra == 'all'
   - adbc-driver-manager ; extra == 'all'
   requires_python: '>=3.10.0'
-- pypi: https://files.pythonhosted.org/packages/6f/d6/8f9a6b1fbcc669108ec6a4d625a70be9e480b437ed9b70cd56b78cd577a6/duckdb-1.5.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/26/78/eb1e064ea8b9df3b87b167bfd7a407b2f615a4291e06cba756727adfa06c/duckdb-1.5.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
   name: duckdb
-  version: 1.5.1
-  sha256: 8150c569b2aa4573b51ba8475e814aa41fd53a3d510c1ffb96f1139f46faf611
+  version: 1.5.2
+  sha256: c99ef73a277c8921bc0a1f16dee38d924484251d9cfd20951748c20fcd5ed855
   requires_dist:
   - ipython ; extra == 'all'
   - fsspec ; extra == 'all'
@@ -1817,10 +1820,10 @@ packages:
   - pyarrow ; extra == 'all'
   - adbc-driver-manager ; extra == 'all'
   requires_python: '>=3.10.0'
-- pypi: https://files.pythonhosted.org/packages/87/03/293bccd838a293d42ea26dec7f4eb4f58b57b6c9ffcfabc6518a5f20a24a/duckdb-1.5.1-cp312-cp312-macosx_11_0_arm64.whl
+- pypi: https://files.pythonhosted.org/packages/2d/8a/3e25b5d03bcf1fb99d189912f8ce92b1db4f9c8778e1b1f55745973a855a/duckdb-1.5.2-cp312-cp312-macosx_10_13_x86_64.whl
   name: duckdb
-  version: 1.5.1
-  sha256: ed6d23a3f806898e69c77430ebd8da0c79c219f97b9acbc9a29a653e09740c59
+  version: 1.5.2
+  sha256: d72b8856b1839d35648f38301b058f6232f4d36b463fe4dc8f4d3fdff2df1a2e
   requires_dist:
   - ipython ; extra == 'all'
   - fsspec ; extra == 'all'
@@ -2056,10 +2059,10 @@ packages:
   - pkg:pypi/h2?source=hash-mapping
   size: 95967
   timestamp: 1756364871835
-- pypi: https://files.pythonhosted.org/packages/53/8a/5b1a62458e862c86a66bafaa63f5e27268bbf47a726b9161be16c25605c0/hail-0.2.137-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/b0/95/1aeb6cc7c4fd0f61088315a9056e37f4d2faa5316051eabb55b4ec602265/hail-0.2.138-py3-none-any.whl
   name: hail
-  version: 0.2.137
-  sha256: b93b8bc2ef9280258d5e4782fea61f7a1c7eea8977fb88a20ad534b5d5611868
+  version: 0.2.138
+  sha256: 9d995a97b4f8eee7478203ec5acf1af2036e80ac1dd8bdc4fa4ac8ab114a1ac5
   requires_dist:
   - aiodns>=2.0.0,<3
   - aiohttp>=3.11.16,<4
@@ -2080,6 +2083,7 @@ packages:
   - typer>=0.9.0,<1
   - python-json-logger>=2.0.2,<3
   - pyyaml>=6.0,<7.0
+  - setuptools>=80.9.0,<82.0.0
   - sortedcontainers>=2.4.0,<3
   - tabulate>=0.8.9,<1
   - uvloop>=0.19.0,<0.22.0 ; sys_platform != 'win32'
@@ -2976,9 +2980,9 @@ packages:
   purls: []
   size: 790176
   timestamp: 1754908768807
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
-  sha256: cc9aba923eea0af8e30e0f94f2ad7156e2984d80d1e8e7fe6be5a1f257f0eb32
-  md5: 8397539e3a0bbd1695584fb4f927485a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
+  sha256: 10056646c28115b174de81a44e23e3a0a3b95b5347d2e6c45cc6d49d35294256
+  md5: 6178c6f2fb254558238ef4e6c56fb782
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -2986,8 +2990,8 @@ packages:
   - jpeg <0.0.0a
   license: IJG AND BSD-3-Clause AND Zlib
   purls: []
-  size: 633710
-  timestamp: 1762094827865
+  size: 633831
+  timestamp: 1775962768273
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h47877c9_openblas.conda
   build_number: 6
   sha256: 371f517eb7010b21c6cc882c7606daccebb943307cb9a3bf2c70456a5c024f7d
@@ -3217,17 +3221,17 @@ packages:
   purls: []
   size: 4308797
   timestamp: 1774472508546
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
-  sha256: 06323fb0a831440f0b72a53013182e1d4bb219e3ea958bb37af98b25dc0cf518
-  md5: 06f225e6d8c549ad6c0201679828a882
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+  sha256: 377cfe037f3eeb3b1bf3ad333f724a64d32f315ee1958581fc671891d63d3f89
+  md5: eba48a68a1a2b9d3c0d9511548db85db
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libzlib >=1.3.2,<2.0a0
   license: zlib-acknowledgement
   purls: []
-  size: 317779
-  timestamp: 1775692841709
+  size: 317729
+  timestamp: 1776315175087
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
   sha256: ec37c79f737933bbac965f5dc0f08ef2790247129a84bb3114fad4900adce401
   md5: 810d83373448da85c3f673fbcb7ad3a3
@@ -3724,18 +3728,18 @@ packages:
   version: 3.11.8
   sha256: 53a0f57e59a530d18a142f4d4ba6dfc708dc5fdedce45e98ff06b44930a2a48f
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
-  sha256: c1fc0f953048f743385d31c468b4a678b3ad20caffdeaa94bed85ba63049fd58
-  md5: b76541e68fea4d511b1ac46a28dcd2c6
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
+  sha256: 171d977bc977fd80f2a05de3d4b7d571c4ec3cdea436ed364e5cd50547c50881
+  md5: b8ae38639d323d808da535fb71e31be8
   depends:
   - python >=3.8
   - python
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/packaging?source=hash-mapping
-  size: 72010
-  timestamp: 1769093650580
+  - pkg:pypi/packaging?source=compressed-mapping
+  size: 89360
+  timestamp: 1776209387231
 - pypi: https://files.pythonhosted.org/packages/5c/bd/bf8064d9cfa214294356c2d6702b716d3cf3bb24be59287a6a21e24cae6b/pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl
   name: pandas
   version: 2.3.3
@@ -4412,36 +4416,36 @@ packages:
   version: '3.0'
   sha256: b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/81/5a/2225f4c176dbfed0d809e848b50ef08f70e61daa667b7fa14b0d311ae44d/pydantic-2.13.1-py3-none-any.whl
   name: pydantic
-  version: 2.12.5
-  sha256: e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d
+  version: 2.13.1
+  sha256: 9557ecc2806faaf6037f85b1fbd963d01e30511c48085f0d573650fdeaad378a
   requires_dist:
   - annotated-types>=0.6.0
-  - pydantic-core==2.41.5
+  - pydantic-core==2.46.1
   - typing-extensions>=4.14.1
   - typing-inspection>=0.4.2
   - email-validator>=2.0.0 ; extra == 'email'
   - tzdata ; python_full_version >= '3.9' and sys_platform == 'win32' and extra == 'timezone'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/a1/a3/09d929a40e6727274b0b500ad06e1b3f35d4f4665ae1c8ba65acbb17e9b5/pydantic_core-2.46.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: pydantic-core
-  version: 2.41.5
-  sha256: eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c
+  version: 2.46.1
+  sha256: a641cb1e74b44c418adaf9f5f450670dbec53511f030d8cde8d8accb66edc363
   requires_dist:
   - typing-extensions>=4.14.1
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/ce/fb/caaa8ee23861c170f07dbd58fc2be3a2c02a32637693cbb23eef02e84808/pydantic_core-2.46.1-cp312-cp312-macosx_10_12_x86_64.whl
   name: pydantic-core
-  version: 2.41.5
-  sha256: f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7
+  version: 2.46.1
+  sha256: ae8c8c5eb4c796944f3166f2f0dab6c761c2c2cc5bd20e5f692128be8600b9a4
   requires_dist:
   - typing-extensions>=4.14.1
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl
+- pypi: https://files.pythonhosted.org/packages/fa/61/bcffaa52894489ff89e5e1cdde67429914bf083c0db7296bef153020f786/pydantic_core-2.46.1-cp312-cp312-macosx_11_0_arm64.whl
   name: pydantic-core
-  version: 2.41.5
-  sha256: 070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0
+  version: 2.46.1
+  sha256: daba6f5f5b986aa0682623a1a4f8d1ecb0ec00ce09cfa9ca71a3b742bc383e3a
   requires_dist:
   - typing-extensions>=4.14.1
   requires_python: '>=3.9'
@@ -5012,6 +5016,63 @@ packages:
   - ruff>=0.12.0 ; extra == 'dev'
   - cython-lint>=0.12.2 ; extra == 'dev'
   requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl
+  name: setuptools
+  version: 81.0.0
+  sha256: fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6
+  requires_dist:
+  - pytest>=6,!=8.1.* ; extra == 'test'
+  - virtualenv>=13.0.0 ; extra == 'test'
+  - wheel>=0.44.0 ; extra == 'test'
+  - pip>=19.1 ; extra == 'test'
+  - packaging>=24.2 ; extra == 'test'
+  - jaraco-envs>=2.2 ; extra == 'test'
+  - pytest-xdist>=3 ; extra == 'test'
+  - jaraco-path>=3.7.2 ; extra == 'test'
+  - build[virtualenv]>=1.0.3 ; extra == 'test'
+  - filelock>=3.4.0 ; extra == 'test'
+  - ini2toml[lite]>=0.14 ; extra == 'test'
+  - tomli-w>=1.0.0 ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest-perf ; sys_platform != 'cygwin' and extra == 'test'
+  - jaraco-develop>=7.21 ; python_full_version >= '3.9' and sys_platform != 'cygwin' and extra == 'test'
+  - pytest-home>=0.5 ; extra == 'test'
+  - pytest-subprocess ; extra == 'test'
+  - pyproject-hooks!=1.1 ; extra == 'test'
+  - jaraco-test>=5.5 ; extra == 'test'
+  - sphinx>=3.5 ; extra == 'doc'
+  - jaraco-packaging>=9.3 ; extra == 'doc'
+  - rst-linker>=1.9 ; extra == 'doc'
+  - furo ; extra == 'doc'
+  - sphinx-lint ; extra == 'doc'
+  - jaraco-tidelift>=1.4 ; extra == 'doc'
+  - pygments-github-lexers==0.0.5 ; extra == 'doc'
+  - sphinx-favicon ; extra == 'doc'
+  - sphinx-inline-tabs ; extra == 'doc'
+  - sphinx-reredirects ; extra == 'doc'
+  - sphinxcontrib-towncrier ; extra == 'doc'
+  - sphinx-notfound-page>=1,<2 ; extra == 'doc'
+  - pyproject-hooks!=1.1 ; extra == 'doc'
+  - towncrier<24.7 ; extra == 'doc'
+  - packaging>=24.2 ; extra == 'core'
+  - more-itertools>=8.8 ; extra == 'core'
+  - jaraco-text>=3.7 ; extra == 'core'
+  - importlib-metadata>=6 ; python_full_version < '3.10' and extra == 'core'
+  - tomli>=2.0.1 ; python_full_version < '3.11' and extra == 'core'
+  - wheel>=0.43.0 ; extra == 'core'
+  - platformdirs>=4.2.2 ; extra == 'core'
+  - jaraco-functools>=4 ; extra == 'core'
+  - more-itertools ; extra == 'core'
+  - pytest-checkdocs>=2.4 ; extra == 'check'
+  - pytest-ruff>=0.2.1 ; sys_platform != 'cygwin' and extra == 'check'
+  - ruff>=0.13.0 ; sys_platform != 'cygwin' and extra == 'check'
+  - pytest-cov ; extra == 'cover'
+  - pytest-enabler>=2.2 ; extra == 'enabler'
+  - pytest-mypy ; extra == 'type'
+  - mypy==1.18.* ; extra == 'type'
+  - importlib-metadata>=7.0.2 ; python_full_version < '3.10' and extra == 'type'
+  - jaraco-develop>=7.21 ; sys_platform != 'cygwin' and extra == 'type'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
   name: shellingham
   version: 1.5.4
@@ -5022,9 +5083,9 @@ packages:
   version: 1.17.0
   sha256: 4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*'
-- conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.5.1-pyhcf101f3_0.conda
-  sha256: f53c2c89e3efddd4a0aafcd6ff525811685ae6a4ba87c9e884c4e681cc90a462
-  md5: bdb3de24557a6b6e6283d2ed5daf8e01
+- conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.6.0-pyhcf101f3_0.conda
+  sha256: 435636387b2ef076cd9fb0a66b68182746f8942b056665128c1724ef583e4c42
+  md5: 458a05a84fe73bf082c0cf7d8a716c69
   depends:
   - python >=3.10
   - wrapt
@@ -5033,8 +5094,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/smart-open?source=hash-mapping
-  size: 56802
-  timestamp: 1771856898593
+  size: 57157
+  timestamp: 1776091507089
 - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhd8ed1ab_0.conda
   sha256: ae723ba6ab7b1998a04ef16b357c1e0043ffd4f4ac9b0da71e393680343a3c86
   md5: 69db183edbe5b7c3e6c157980057a9d0


### PR DESCRIPTION
## Summary

- Ports `remap_divref.py` (`calitas` subcommand) from `human-diversity-reference/scripts` as a defopt-compatible toolkit tool
- Remaps DivRef haplotype-space coordinates to reference genome positions for CALITAS output files, using the DivRef DuckDB index produced by `create_fasta_and_index`
- Adds full type annotations, Pydantic `frozen=True` models (`Variant`, `ReferenceMapping`, `Haplotype`) with field aliases for DB column names, and replaces `typer` error handling with `RuntimeError`/`ValueError`
- Adds `pandas` to the `mypy` `ignore_missing_imports` override
- Fixes coordinate translation to match upstream v1.1: sign-dependent check in `_translate_coordinate_to_ref` and gap-stripping in `padded_len_adj`
- Adds `tests/tools/test_remap_divref.py` with six tests covering coordinate translation, gap handling, and haplotype remapping; all pass

## Test plan

- [x] `uv run --directory divref poe check-all` passes
- [x] `uv run --directory divref pytest tests/tools/test_remap_divref.py` — all six tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `remap_divref` command-line tool to convert CALITAS haplotype sequence coordinates to DivRef reference genome coordinates.

* **Tests**
  * Added comprehensive test suite covering SNP variants, insertions, deletions, and complex multi-indel coordinate mapping scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->