### PR TITLE
test: enable Hail tests via session fixture and CI Java setup

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -26,7 +26,7 @@ jobs:
           cache-suffix: ${{ matrix.PYTHON_VERSION }}
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
         with:
           distribution: temurin
           java-version: '11'

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -25,6 +25,12 @@ jobs:
           enable-cache: 'true'
           cache-suffix: ${{ matrix.PYTHON_VERSION }}
 
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'
+
       - name: Test the library
         run: |
           uv run --directory divref --locked poe check-all

--- a/divref/tests/conftest.py
+++ b/divref/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Shared pytest fixtures for the divref test suite."""
+
+from collections.abc import Generator
+
+import hail as hl
+import pytest
+
+
+@pytest.fixture(scope="session")
+def hail_context() -> Generator[None, None, None]:
+    """
+    Initialize a local Hail context for the test session.
+
+    Starts a local Spark/JVM context once per session and stops it on exit.
+    Tests that use Hail expressions must request this fixture explicitly.
+    Requires Java 11+ to be available in PATH (provided by pixi or setup-java).
+    """
+    hl.init(quiet=True)
+    yield
+    hl.stop()

--- a/divref/tests/tools/test_create_fasta_and_index.py
+++ b/divref/tests/tools/test_create_fasta_and_index.py
@@ -55,8 +55,7 @@ def _create_reference_mock(reference_sequence: str) -> Any:
     return mock_get_sequence
 
 
-@pytest.mark.skip(reason="Requires a running Hail/Spark JVM context")
-def test_get_haplo_sequence_edge_cases() -> None:
+def test_get_haplo_sequence_edge_cases(hail_context: None) -> None:  # noqa: ARG001
     """Test get_haplo_sequence with SNPs, insertions, and deletions."""
     reference = "01234567891"
 


### PR DESCRIPTION
## Summary

- Adds `divref/tests/conftest.py` with a session-scoped `hail_context` fixture that calls `hl.init(quiet=True)` once per test session and `hl.stop()` on exit
- Removes `@pytest.mark.skip` from `test_get_haplo_sequence_edge_cases` — the test already mocked `hl.get_sequence` correctly and only needed an active Hail context to call `hl.eval()`
- Adds a `setup-java` step (Temurin JDK 11) to `python_package.yml` so `hl.init()` can find a JVM on the GitHub Actions runner

## How it works

Tests that require Hail add `hail_context: None` as a parameter; pytest injects the session fixture, ensuring `hl.init()` has been called before any Hail expressions are evaluated. The fixture is not `autouse`, so non-Hail tests incur no startup overhead.

## Test plan

- [ ] `pixi run check-all` passes locally (Java provided by pixi `hail` feature)
- [ ] Python toolkit checks CI passes with Java available (JDK 11 via setup-java)
- [ ] `test_get_haplo_sequence_edge_cases` passes (not skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)