### PR TITLE
refactor: replace Any annotations, use Path for local paths, add missing docstrings

### DIFF
--- a/divref/divref/alias.py
+++ b/divref/divref/alias.py
@@ -1,8 +1,4 @@
-from typing import Any
 from typing import TypeAlias
 
 HailPath: TypeAlias = str
 """Type alias for filesystem paths accepted by Hail: local, GCS (gs://), or HDFS (hdfs://)."""
-
-HailExpression: TypeAlias = Any
-"""Type alias for Hail DSL expression objects, which are opaque to the mypy type checker."""

--- a/divref/divref/alias.py
+++ b/divref/divref/alias.py
@@ -1,4 +1,8 @@
+from typing import Any
 from typing import TypeAlias
 
 HailPath: TypeAlias = str
 """Type alias for filesystem paths accepted by Hail: local, GCS (gs://), or HDFS (hdfs://)."""
+
+HailExpression: TypeAlias = Any
+"""Type alias for Hail DSL expression objects, which are opaque to the mypy type checker."""

--- a/divref/divref/haplotype.py
+++ b/divref/divref/haplotype.py
@@ -1,12 +1,12 @@
 """Shared utilities for Hail-based DivRef pipeline tools."""
 
-from typing import Any
 from typing import Hashable
 from typing import TypeVar
 
 import hail as hl
 
 from divref import defaults
+from divref.alias import HailExpression
 
 _V = TypeVar("_V", bound=Hashable)
 """Type variable for hashable dictionary values used in to_hashable_items."""
@@ -26,8 +26,10 @@ def to_hashable_items(d: dict[str, _V]) -> tuple[tuple[str, _V], ...]:
 
 
 def get_haplo_sequence(
-    context_size: int, variants: Any, reference_genome: str = defaults.REFERENCE_GENOME
-) -> Any:
+    context_size: int,
+    variants: HailExpression,
+    reference_genome: str = defaults.REFERENCE_GENOME,
+) -> HailExpression:
     """
     Construct a haplotype sequence string with flanking genomic context.
 
@@ -68,7 +70,17 @@ def get_haplo_sequence(
     # (min_pos - index_translation) equals context_size, mapping locus positions to string indices
     index_translation = min_pos - context_size
 
-    def get_chunk_until_next_variant(i: Any) -> Any:
+    def get_chunk_until_next_variant(i: HailExpression) -> HailExpression:
+        """
+        Return the alternate allele plus intervening reference bases up to the next variant.
+
+        Args:
+            i: Hail integer expression indexing into sorted_variants.
+
+        Returns:
+            Hail string expression for the alternate allele concatenated with the
+            reference bases between this variant and the next (or the trailing context).
+        """
         v = sorted_variants[i]
         variant_size = hl.len(v.alleles[0])
         reference_buffer_size = hl.if_else(
@@ -85,7 +97,7 @@ def get_haplo_sequence(
     )
 
 
-def variant_distance(v1: Any, v2: Any) -> Any:
+def variant_distance(v1: HailExpression, v2: HailExpression) -> HailExpression:
     """
     Calculate the number of reference bases between two variants.
 
@@ -122,7 +134,16 @@ def split_haplotypes(ht: hl.Table, window_size: int) -> hl.Table:
         lambda i: variant_distance(ht.variants[i - 1], ht.variants[i]) >= window_size
     )
 
-    def get_range(i: Any) -> Any:
+    def get_range(i: HailExpression) -> HailExpression:
+        """
+        Return the range of variant indices for the i-th haplotype segment.
+
+        Args:
+            i: Hail integer expression for the segment index.
+
+        Returns:
+            Hail range expression of variant indices belonging to segment i.
+        """
         start_index = hl.if_else(i == 0, 0, breakpoints[i - 1])
         end_index = hl.if_else(i == hl.len(breakpoints), hl.len(ht.variants), breakpoints[i])
         return hl.range(start_index, end_index)

--- a/divref/divref/haplotype.py
+++ b/divref/divref/haplotype.py
@@ -6,7 +6,6 @@ from typing import TypeVar
 import hail as hl
 
 from divref import defaults
-from divref.alias import HailExpression
 
 _V = TypeVar("_V", bound=Hashable)
 """Type variable for hashable dictionary values used in to_hashable_items."""
@@ -27,9 +26,9 @@ def to_hashable_items(d: dict[str, _V]) -> tuple[tuple[str, _V], ...]:
 
 def get_haplo_sequence(
     context_size: int,
-    variants: HailExpression,
+    variants: hl.Expression,
     reference_genome: str = defaults.REFERENCE_GENOME,
-) -> HailExpression:
+) -> hl.Expression:
     """
     Construct a haplotype sequence string with flanking genomic context.
 
@@ -70,7 +69,7 @@ def get_haplo_sequence(
     # (min_pos - index_translation) equals context_size, mapping locus positions to string indices
     index_translation = min_pos - context_size
 
-    def get_chunk_until_next_variant(i: HailExpression) -> HailExpression:
+    def get_chunk_until_next_variant(i: hl.Expression) -> hl.Expression:
         """
         Return the alternate allele plus intervening reference bases up to the next variant.
 
@@ -97,7 +96,7 @@ def get_haplo_sequence(
     )
 
 
-def variant_distance(v1: HailExpression, v2: HailExpression) -> HailExpression:
+def variant_distance(v1: hl.Expression, v2: hl.Expression) -> hl.Expression:
     """
     Calculate the number of reference bases between two variants.
 
@@ -134,7 +133,7 @@ def split_haplotypes(ht: hl.Table, window_size: int) -> hl.Table:
         lambda i: variant_distance(ht.variants[i - 1], ht.variants[i]) >= window_size
     )
 
-    def get_range(i: HailExpression) -> HailExpression:
+    def get_range(i: hl.Expression) -> hl.Expression:
         """
         Return the range of variant indices for the i-th haplotype segment.
 

--- a/divref/divref/main.py
+++ b/divref/divref/main.py
@@ -11,6 +11,7 @@ from divref.tools.compute_variation_ratios import compute_variation_ratios
 from divref.tools.create_fasta_and_index import create_fasta_and_index
 from divref.tools.create_gnomad_sites_vcf import create_gnomad_sites_vcf
 from divref.tools.extract_gnomad_afs import extract_gnomad_afs
+from divref.tools.extract_gnomad_single_afs import extract_gnomad_single_afs
 from divref.tools.extract_sample_metadata import extract_sample_metadata
 from divref.tools.gnomad_hail_table_test_data import gnomad_hail_table_test_data
 from divref.tools.remap_divref import remap_divref
@@ -22,6 +23,7 @@ _tools: List[Callable[..., None]] = [
     create_fasta_and_index,
     create_gnomad_sites_vcf,
     extract_gnomad_afs,
+    extract_gnomad_single_afs,
     extract_sample_metadata,
     gnomad_hail_table_test_data,
     remap_divref,
@@ -29,7 +31,12 @@ _tools: List[Callable[..., None]] = [
 
 
 def setup_logging(level: str = "INFO") -> None:
-    """Set up basic logging to print to the console."""
+    """
+    Set up basic logging to print to the console.
+
+    Args:
+        level: Logging level string (e.g. "INFO", "DEBUG", "WARNING").
+    """
     logging.basicConfig(
         level=level,
         format="%(asctime)s %(name)s:%(funcName)s:%(lineno)s [%(levelname)s]: %(message)s",

--- a/divref/divref/main.py
+++ b/divref/divref/main.py
@@ -11,7 +11,6 @@ from divref.tools.compute_variation_ratios import compute_variation_ratios
 from divref.tools.create_fasta_and_index import create_fasta_and_index
 from divref.tools.create_gnomad_sites_vcf import create_gnomad_sites_vcf
 from divref.tools.extract_gnomad_afs import extract_gnomad_afs
-from divref.tools.extract_gnomad_single_afs import extract_gnomad_single_afs
 from divref.tools.extract_sample_metadata import extract_sample_metadata
 from divref.tools.gnomad_hail_table_test_data import gnomad_hail_table_test_data
 from divref.tools.remap_divref import remap_divref
@@ -23,7 +22,6 @@ _tools: List[Callable[..., None]] = [
     create_fasta_and_index,
     create_gnomad_sites_vcf,
     extract_gnomad_afs,
-    extract_gnomad_single_afs,
     extract_sample_metadata,
     gnomad_hail_table_test_data,
     remap_divref,

--- a/divref/divref/tools/compute_haplotype_statistics.py
+++ b/divref/divref/tools/compute_haplotype_statistics.py
@@ -3,13 +3,15 @@
 from pathlib import Path
 
 import hail as hl
-from pydantic import BaseModel
+from fgmetric import Metric
+from fgmetric import MetricWriter
+from fgpyo.io import assert_directory_exists
+from fgpyo.io import assert_path_is_writable
 
-from divref.alias import HailPath
 from divref.haplotype import split_haplotypes
 
 
-class _HGDPResult(BaseModel):
+class _HGDPResult(Metric):
     """Summary of unique haplotype count for one (frequency, window_size) parameter combination."""
 
     frequency_cutoff: float
@@ -17,7 +19,7 @@ class _HGDPResult(BaseModel):
     hgdp_haplotype_count: int
 
 
-class _GnomADResult(BaseModel):
+class _GnomADResult(Metric):
     """Count of gnomAD variants above a given frequency cutoff."""
 
     frequency_cutoff: float
@@ -26,8 +28,8 @@ class _GnomADResult(BaseModel):
 
 def compute_haplotype_statistics(
     *,
-    haplotypes_table_path: HailPath,
-    gnomad_va_file: HailPath,
+    haplotypes_table_path: Path,
+    gnomad_va_file: Path,
     window_sizes: list[int],
     frequency_cutoffs: list[float],
     output_base: Path,
@@ -50,44 +52,39 @@ def compute_haplotype_statistics(
         output_base: Base path for output TSV files; writes {output_base}.hgdp.tsv
             and {output_base}.gnomad.tsv.
     """
-    hl.init()
-
-    ht = hl.read_table(haplotypes_table_path).key_by()
-    va = hl.read_table(gnomad_va_file)
-
-    hgdp_results: list[_HGDPResult] = []
-    gnomad_results: list[_GnomADResult] = []
-
-    for frequency in frequency_cutoffs:
-        ht_filtered = ht.filter(hl.max(ht.all_pop_freqs.map(lambda x: x.empirical_AF)) >= frequency)
-        for window_size in window_sizes:
-            ht2 = split_haplotypes(ht_filtered, window_size)
-            n_unique = ht2.key_by("haplotype").distinct().key_by().count()
-            hgdp_results.append(
-                _HGDPResult(
-                    frequency_cutoff=frequency,
-                    window_size=window_size,
-                    hgdp_haplotype_count=n_unique,
-                )
-            )
-
-        gnomad_count = va.filter(hl.max(va.pop_freqs.map(lambda x: x.AF)) >= frequency).count()
-        gnomad_results.append(
-            _GnomADResult(frequency_cutoff=frequency, gnomad_variant_count=gnomad_count)
-        )
+    assert_directory_exists(haplotypes_table_path)
+    assert_directory_exists(gnomad_va_file)
 
     out_hgdp: Path = output_base.with_suffix(".hgdp.tsv")
-    with out_hgdp.open("w") as f:
-        f.write("frequency\twindow_size\thgdp_haplotype_count\n")
-        for hgdp_result in hgdp_results:
-            f.write(
-                f"{hgdp_result.frequency_cutoff}\t"
-                f"{hgdp_result.window_size}\t"
-                f"{hgdp_result.hgdp_haplotype_count}\n"
-            )
-
     out_gnomad: Path = output_base.with_suffix(".gnomad.tsv")
-    with out_gnomad.open("w") as f:
-        f.write("frequency\tgnomad_variant_count\n")
-        for gnomad_result in gnomad_results:
-            f.write(f"{gnomad_result.frequency_cutoff}\t{gnomad_result.gnomad_variant_count}\n")
+    assert_path_is_writable(out_hgdp)
+    assert_path_is_writable(out_gnomad)
+
+    hl.init()
+
+    ht = hl.read_table(str(haplotypes_table_path)).key_by()
+    va = hl.read_table(str(gnomad_va_file))
+
+    with (
+        MetricWriter(_HGDPResult, out_hgdp) as hgdp_writer,
+        MetricWriter(_GnomADResult, out_gnomad) as gnomad_writer,
+    ):
+        for frequency in frequency_cutoffs:
+            ht_filtered = ht.filter(
+                hl.max(ht.all_pop_freqs.map(lambda x: x.empirical_AF)) >= frequency
+            )
+            for window_size in window_sizes:
+                ht2 = split_haplotypes(ht_filtered, window_size)
+                n_unique = ht2.key_by("haplotype").distinct().key_by().count()
+                hgdp_writer.write(
+                    _HGDPResult(
+                        frequency_cutoff=frequency,
+                        window_size=window_size,
+                        hgdp_haplotype_count=n_unique,
+                    )
+                )
+
+            gnomad_count = va.filter(hl.max(va.pop_freqs.map(lambda x: x.AF)) >= frequency).count()
+            gnomad_writer.write(
+                _GnomADResult(frequency_cutoff=frequency, gnomad_variant_count=gnomad_count)
+            )

--- a/divref/divref/tools/compute_haplotypes.py
+++ b/divref/divref/tools/compute_haplotypes.py
@@ -5,9 +5,11 @@ from pathlib import Path
 from typing import Callable
 
 import hail as hl
+from fgpyo.io import assert_directory_exists
+from fgpyo.io import assert_path_is_readable
+from fgpyo.io import assert_path_is_writable
 
 from divref import defaults
-from divref.alias import HailPath
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +18,7 @@ def _get_haplotypes(
     ht: hl.Table,
     windower_f: Callable[[hl.Expression], hl.Expression],
     idx: int,
-    output_base: HailPath,
+    output_base: Path,
     pop_ints: dict[str, int],
 ) -> hl.Table:
     """
@@ -214,17 +216,17 @@ def _get_haplotypes(
     )
 
     logger.info("Writing %s.%s.ht ...", output_base, idx)
-    return hte.checkpoint(f"{output_base}.{idx}.ht", overwrite=True)
+    return hte.checkpoint(f"{str(output_base)}.{idx}.ht", overwrite=True)
 
 
 def compute_haplotypes(
     *,
-    vcfs_path: HailPath,
-    gnomad_va_file: HailPath,
-    gnomad_sa_file: HailPath,
+    vcfs_path: Path,
+    gnomad_va_file: Path,
+    gnomad_sa_file: Path,
     window_size: int,
     freq_threshold: float,
-    output_base: HailPath,
+    output_base: Path,
     temp_dir: Path = Path("/tmp"),
 ) -> None:
     """
@@ -246,14 +248,24 @@ def compute_haplotypes(
             and the final {output_base}.ht.
         temp_dir: Local directory for Hail temporary files.
     """
+    assert_path_is_readable(vcfs_path)
+    assert_directory_exists(gnomad_va_file)
+    assert_directory_exists(gnomad_sa_file)
+    assert_path_is_writable(output_base.with_suffix(output_base.suffix + ".1.ht"))
+    assert_path_is_writable(output_base.with_suffix(output_base.suffix + ".2.ht"))
+    assert_path_is_writable(output_base.with_suffix(output_base.suffix + ".ht"))
+
     hl.init(tmp_dir=str(temp_dir))
 
-    gnomad_sa = hl.read_table(gnomad_sa_file)
-    gnomad_va = hl.read_table(gnomad_va_file)
+    gnomad_sa = hl.read_table(str(gnomad_sa_file))
+    gnomad_va = hl.read_table(str(gnomad_va_file))
     gnomad_va = gnomad_va.filter(hl.max(gnomad_va.pop_freqs.map(lambda x: x.AF)) >= freq_threshold)
 
     mt = hl.import_vcf(
-        vcfs_path, reference_genome=defaults.REFERENCE_GENOME, min_partitions=64, force_bgz=True
+        str(vcfs_path),
+        reference_genome=defaults.REFERENCE_GENOME,
+        min_partitions=64,
+        force_bgz=True,
     )
     mt = mt.select_rows().select_cols()
     mt = mt.annotate_rows(freq=gnomad_va[mt.row_key].pop_freqs)
@@ -300,4 +312,4 @@ def compute_haplotypes(
 
     htu = window1.union(window2)
     logger.info("Writing final %s.ht ...", output_base)
-    htu.key_by("haplotype").naive_coalesce(64).write(f"{output_base}.ht", overwrite=True)
+    htu.key_by("haplotype").naive_coalesce(64).write(f"{str(output_base)}.ht", overwrite=True)

--- a/divref/divref/tools/compute_haplotypes.py
+++ b/divref/divref/tools/compute_haplotypes.py
@@ -7,7 +7,6 @@ from typing import Callable
 import hail as hl
 
 from divref import defaults
-from divref.alias import HailExpression
 from divref.alias import HailPath
 
 logger = logging.getLogger(__name__)
@@ -15,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 def _get_haplotypes(
     ht: hl.Table,
-    windower_f: Callable[[HailExpression], HailExpression],
+    windower_f: Callable[[hl.Expression], hl.Expression],
     idx: int,
     output_base: HailPath,
     pop_ints: dict[str, int],
@@ -41,7 +40,7 @@ def _get_haplotypes(
     new_locus = windower_f(ht.locus)
     ht = ht.annotate(new_locus=new_locus)
 
-    def agg_haplos(arr: HailExpression) -> HailExpression:
+    def agg_haplos(arr: hl.Expression) -> hl.Expression:
         """
         Aggregate haplotypes from an array of population/sample/index structs.
 
@@ -85,8 +84,8 @@ def _get_haplotypes(
     )
 
     def collapse_haplos_across_samples(
-        pop: HailExpression, arr1: HailExpression, arr2: HailExpression
-    ) -> HailExpression:
+        pop: hl.Expression, arr1: hl.Expression, arr2: hl.Expression
+    ) -> hl.Expression:
         """
         Combine haplotypes from the left and right chromosome strands for one population.
 
@@ -106,7 +105,7 @@ def _get_haplotypes(
         # Assumes all AN == 2 * N_samples.
         flat = hl.array([arr1, arr2]).flatmap(lambda x: x.get(pop))
 
-        def map_haplo_group(t: HailExpression) -> HailExpression:
+        def map_haplo_group(t: hl.Expression) -> hl.Expression:
             """
             Summarize one haplotype group into a frequency struct.
 
@@ -141,7 +140,7 @@ def _get_haplotypes(
         )
     )
 
-    def get_haplotype_summary(a: HailExpression) -> dict[str, HailExpression]:
+    def get_haplotype_summary(a: hl.Expression) -> dict[str, hl.Expression]:
         """
         Extract the top-population frequency fields from a collapsed haplotype array.
 
@@ -175,7 +174,7 @@ def _get_haplotypes(
     hte = ht_grouped.explode("all_haplos")
     hte = hte.key_by().drop("new_locus")
 
-    def get_variant(row_idx: HailExpression) -> HailExpression:
+    def get_variant(row_idx: hl.Expression) -> hl.Expression:
         """
         Look up the locus and alleles for a variant by its row index.
 
@@ -188,7 +187,7 @@ def _get_haplotypes(
         """
         return hte.row_map[row_idx].select("locus", "alleles")
 
-    def get_gnomad_freq(row_idx: HailExpression) -> HailExpression:
+    def get_gnomad_freq(row_idx: hl.Expression) -> hl.Expression:
         """
         Look up the gnomAD frequency array for a variant by its row index.
 

--- a/divref/divref/tools/compute_haplotypes.py
+++ b/divref/divref/tools/compute_haplotypes.py
@@ -1,24 +1,25 @@
 """Tool to compute haplotypes from VCF files with gnomAD population frequency annotations."""
 
 import logging
-from typing import Any
+from pathlib import Path
 from typing import Callable
 
 import hail as hl
 
 from divref import defaults
+from divref.alias import HailExpression
 from divref.alias import HailPath
 
 logger = logging.getLogger(__name__)
 
 
 def _get_haplotypes(
-    ht: Any,
-    windower_f: Callable[[Any], Any],
+    ht: hl.Table,
+    windower_f: Callable[[HailExpression], HailExpression],
     idx: int,
     output_base: HailPath,
     pop_ints: dict[str, int],
-) -> Any:
+) -> hl.Table:
     """
     Group variants into haplotypes within genomic windows and compute empirical frequencies.
 
@@ -40,7 +41,22 @@ def _get_haplotypes(
     new_locus = windower_f(ht.locus)
     ht = ht.annotate(new_locus=new_locus)
 
-    def agg_haplos(arr: Any) -> Any:
+    def agg_haplos(arr: HailExpression) -> HailExpression:
+        """
+        Aggregate haplotypes from an array of population/sample/index structs.
+
+        Groups alleles carried by the same sample within a window, collects haplotypes
+        that have more than one observed variant, and counts occurrences per unique
+        variant-index sequence (the "haplotype").
+
+        Args:
+            arr: Hail array expression of structs with pop, sample, and row_idx fields,
+                representing alleles carried by samples on one haploid chromosome.
+
+        Returns:
+            Hail dict expression mapping population integer to an array of
+            (haplotype, count) pairs, where haplotype is an array of row indices.
+        """
         flat = hl.agg.explode(lambda elt: hl.agg.collect(elt.annotate(row_idx=ht.row_idx)), arr)
         pop_grouped = hl.group_by(lambda x: x.pop, flat)
         return pop_grouped.map_values(
@@ -68,11 +84,39 @@ def _get_haplotypes(
         right_haplos=agg_haplos(ht.pops_and_ids_right),
     )
 
-    def collapse_haplos_across_samples(pop: Any, arr1: Any, arr2: Any) -> Any:
+    def collapse_haplos_across_samples(
+        pop: HailExpression, arr1: HailExpression, arr2: HailExpression
+    ) -> HailExpression:
+        """
+        Combine haplotypes from the left and right chromosome strands for one population.
+
+        Merges the two strand dictionaries for the given population, groups identical
+        haplotypes (sequences of row indices), and computes empirical allele counts and
+        frequencies using the minimum allele number across component variants.
+
+        Args:
+            pop: Hail integer expression identifying the population.
+            arr1: Left-strand haplotype dict from agg_haplos.
+            arr2: Right-strand haplotype dict from agg_haplos.
+
+        Returns:
+            Hail array expression of structs with haplotype, pop, empirical_AC,
+            min_variant_frequency, and empirical_AF fields.
+        """
         # Assumes all AN == 2 * N_samples.
         flat = hl.array([arr1, arr2]).flatmap(lambda x: x.get(pop))
 
-        def map_haplo_group(t: Any) -> Any:
+        def map_haplo_group(t: HailExpression) -> HailExpression:
+            """
+            Summarize one haplotype group into a frequency struct.
+
+            Args:
+                t: Tuple of (haplotype_row_indices, list_of_count_pairs).
+
+            Returns:
+                Hail struct with haplotype, pop, empirical_AC, min_variant_frequency,
+                and empirical_AF.
+            """
             haplotype = t[0]
             n_observed = hl.sum(t[1].map(lambda x: x[1]))
             component_variant_frequencies = haplotype.map(
@@ -97,7 +141,22 @@ def _get_haplotypes(
         )
     )
 
-    def get_haplotype_summary(a: Any) -> dict[str, Any]:
+    def get_haplotype_summary(a: HailExpression) -> dict[str, HailExpression]:
+        """
+        Extract the top-population frequency fields from a collapsed haplotype array.
+
+        Sorts the array of per-population frequency structs by empirical AF descending
+        and returns the fields of the maximum-frequency entry along with the full
+        population frequency array.
+
+        Args:
+            a: Hail array expression of per-population frequency structs (from
+                collapse_haplos_across_samples), one entry per population.
+
+        Returns:
+            Dict mapping field names to Hail expressions for max_pop, max_empirical_AF,
+            max_empirical_AC, min_variant_frequency, and all_pop_freqs.
+        """
         a_sorted = hl.sorted(a, key=lambda x: x.empirical_AF, reverse=True)
         return dict(
             max_pop=a_sorted[0].pop,
@@ -116,10 +175,30 @@ def _get_haplotypes(
     hte = ht_grouped.explode("all_haplos")
     hte = hte.key_by().drop("new_locus")
 
-    def get_variant(row_idx: Any) -> Any:
+    def get_variant(row_idx: HailExpression) -> HailExpression:
+        """
+        Look up the locus and alleles for a variant by its row index.
+
+        Args:
+            row_idx: Hail integer expression for the variant's row index in the
+                checkpoint table.
+
+        Returns:
+            Hail struct expression with locus and alleles fields.
+        """
         return hte.row_map[row_idx].select("locus", "alleles")
 
-    def get_gnomad_freq(row_idx: Any) -> Any:
+    def get_gnomad_freq(row_idx: HailExpression) -> HailExpression:
+        """
+        Look up the gnomAD frequency array for a variant by its row index.
+
+        Args:
+            row_idx: Hail integer expression for the variant's row index in the
+                checkpoint table.
+
+        Returns:
+            Hail array expression of per-population gnomAD frequency structs.
+        """
         return hte.row_map[row_idx].freq
 
     hte = hte.select(
@@ -147,7 +226,7 @@ def compute_haplotypes(
     window_size: int,
     freq_threshold: float,
     output_base: HailPath,
-    temp_dir: HailPath = "/tmp",
+    temp_dir: Path = Path("/tmp"),
 ) -> None:
     """
     Compute population haplotypes from VCF files with gnomAD frequency annotations.
@@ -166,9 +245,9 @@ def compute_haplotypes(
         freq_threshold: Minimum gnomAD population allele frequency to retain a variant.
         output_base: Base output path; writes {output_base}.1.ht, {output_base}.2.ht,
             and the final {output_base}.ht.
-        temp_dir: Directory for Hail temporary files.
+        temp_dir: Local directory for Hail temporary files.
     """
-    hl.init(tmp_dir=temp_dir)
+    hl.init(tmp_dir=str(temp_dir))
 
     gnomad_sa = hl.read_table(gnomad_sa_file)
     gnomad_va = hl.read_table(gnomad_va_file)

--- a/divref/divref/tools/compute_haplotypes.py
+++ b/divref/divref/tools/compute_haplotypes.py
@@ -237,7 +237,7 @@ def compute_haplotypes(
     and writes the union of both windowed results as a keyed Hail table.
 
     Args:
-        vcfs_path: Path or glob pattern to input VCF files (GRCh38).
+        vcfs_path: Path or glob pattern to input VCF files.
         gnomad_va_file: Path to the gnomAD variant annotations Hail table
             (from extract_gnomad_afs).
         gnomad_sa_file: Path to the gnomAD sample metadata Hail table

--- a/divref/divref/tools/compute_variation_ratios.py
+++ b/divref/divref/tools/compute_variation_ratios.py
@@ -17,6 +17,7 @@ def compute_variation_ratios(
     gnomad_sa_file: Path,
     output_ht: Path,
     frequency_thresholds: list[float] = defaults.VARIATION_RATIO_FREQUENCY_THRESHOLDS,
+    reference_genome: str = defaults.REFERENCE_GENOME,
 ) -> None:
     """
     Compute per-sample counts of non-reference variant sites across frequency thresholds.
@@ -26,13 +27,14 @@ def compute_variation_ratios(
     sample-level Hail table with population labels and per-threshold site counts.
 
     Args:
-        vcfs_path: Path or glob pattern to input VCF files (GRCh38).
+        vcfs_path: Path or glob pattern to input VCF files.
         gnomad_va_file: Path to the gnomAD variant annotations Hail table
             (from extract_gnomad_afs).
         gnomad_sa_file: Path to the gnomAD sample metadata Hail table
             (from extract_gnomad_afs).
         output_ht: Output path for the sample-level Hail table.
         frequency_thresholds: Frequency thresholds to calculate.
+        reference_genome: Reference genome to use. Defaults to "GRCh38".
     """
     assert_path_is_readable(vcfs_path)
     assert_directory_exists(gnomad_va_file)
@@ -51,7 +53,7 @@ def compute_variation_ratios(
     gnomad_sa = hl.read_table(str(gnomad_sa_file))
     gnomad_va = hl.read_table(str(gnomad_va_file))
 
-    mt = hl.import_vcf(str(vcfs_path), reference_genome="GRCh38", min_partitions=64)
+    mt = hl.import_vcf(str(vcfs_path), reference_genome=reference_genome, min_partitions=64)
     mt = mt.select_rows().select_cols()
     mt = mt.annotate_rows(freq=gnomad_va[mt.row_key].pop_freqs)
     mt = mt.filter_rows(hl.is_defined(mt.freq))

--- a/divref/divref/tools/compute_variation_ratios.py
+++ b/divref/divref/tools/compute_variation_ratios.py
@@ -1,17 +1,21 @@
 """Tool to compute per-sample variant site counts across gnomAD frequency thresholds."""
 
+from pathlib import Path
+
 import hail as hl
+from fgpyo.io import assert_directory_exists
+from fgpyo.io import assert_path_is_readable
+from fgpyo.io import assert_path_is_writable
 
 from divref import defaults
-from divref.alias import HailPath
 
 
 def compute_variation_ratios(
     *,
-    vcfs_path: HailPath,
-    gnomad_va_file: HailPath,
-    gnomad_sa_file: HailPath,
-    output_ht: HailPath,
+    vcfs_path: Path,
+    gnomad_va_file: Path,
+    gnomad_sa_file: Path,
+    output_ht: Path,
     frequency_thresholds: list[float] = defaults.VARIATION_RATIO_FREQUENCY_THRESHOLDS,
 ) -> None:
     """
@@ -30,6 +34,11 @@ def compute_variation_ratios(
         output_ht: Output path for the sample-level Hail table.
         frequency_thresholds: Frequency thresholds to calculate.
     """
+    assert_path_is_readable(vcfs_path)
+    assert_directory_exists(gnomad_va_file)
+    assert_directory_exists(gnomad_sa_file)
+    assert_path_is_writable(output_ht)
+
     if any(t < 0 or t > 1 for t in frequency_thresholds):
         raise ValueError("All frequency_thresholds must be in [0, 1].")
 
@@ -39,10 +48,10 @@ def compute_variation_ratios(
 
     hl.init()
 
-    gnomad_sa = hl.read_table(gnomad_sa_file)
-    gnomad_va = hl.read_table(gnomad_va_file)
+    gnomad_sa = hl.read_table(str(gnomad_sa_file))
+    gnomad_va = hl.read_table(str(gnomad_va_file))
 
-    mt = hl.import_vcf(vcfs_path, reference_genome="GRCh38", min_partitions=64)
+    mt = hl.import_vcf(str(vcfs_path), reference_genome="GRCh38", min_partitions=64)
     mt = mt.select_rows().select_cols()
     mt = mt.annotate_rows(freq=gnomad_va[mt.row_key].pop_freqs)
     mt = mt.filter_rows(hl.is_defined(mt.freq))
@@ -58,4 +67,4 @@ def compute_variation_ratios(
         })
     )
 
-    mt.cols().write(output_ht, overwrite=True)
+    mt.cols().write(str(output_ht), overwrite=True)

--- a/divref/divref/tools/compute_variation_ratios.py
+++ b/divref/divref/tools/compute_variation_ratios.py
@@ -27,7 +27,7 @@ def compute_variation_ratios(
     sample-level Hail table with population labels and per-threshold site counts.
 
     Args:
-        vcfs_path: Path or glob pattern to input VCF files.
+        vcfs_path: Path to input VCF files.
         gnomad_va_file: Path to the gnomAD variant annotations Hail table
             (from extract_gnomad_afs).
         gnomad_sa_file: Path to the gnomAD sample metadata Hail table

--- a/divref/divref/tools/create_fasta_and_index.py
+++ b/divref/divref/tools/create_fasta_and_index.py
@@ -56,7 +56,7 @@ def build_haplotype_table(
     va = hl.read_table(str(gnomad_va_file))
     pops_legend: list[str] = va.pops.collect()[0]
 
-    hl.get_reference(reference_genome).add_sequence(reference_fasta)
+    hl.get_reference(reference_genome).add_sequence(str(reference_fasta))
 
     logger.info(
         "Haplotype table contains %d unique haplotypes above frequency threshold", ht.count()
@@ -291,7 +291,7 @@ def create_fasta_and_index(
     assert_path_is_writable(tmp_dir)
     assert_path_is_writable(output_base)
 
-    hl.init(tmp_dir=tmp_dir)
+    hl.init(tmp_dir=str(tmp_dir))
 
     ht, pops_legend = build_haplotype_table(
         haplotypes_table_path=haplotypes_table_path,

--- a/divref/divref/tools/create_fasta_and_index.py
+++ b/divref/divref/tools/create_fasta_and_index.py
@@ -13,9 +13,9 @@ from fgpyo.io import assert_fasta_indexed
 from fgpyo.io import assert_path_is_readable
 from fgpyo.io import assert_path_is_writable
 
+from divref import defaults
 from divref.haplotype import get_haplo_sequence
 from divref.haplotype import split_haplotypes
-from divref import defaults
 
 logger = logging.getLogger(__name__)
 
@@ -301,6 +301,7 @@ def create_fasta_and_index(
         frequency_cutoff=frequency_cutoff,
         merge=merge,
         version_str=version_str,
+        reference_genome=reference_genome,
         tmp_dir=tmp_dir,
     )
 

--- a/divref/divref/tools/create_fasta_and_index.py
+++ b/divref/divref/tools/create_fasta_and_index.py
@@ -3,12 +3,16 @@
 import json
 import logging
 import os
+from pathlib import Path
 
 import duckdb
 import hail as hl
 import polars
+from fgpyo.io import assert_directory_exists
+from fgpyo.io import assert_fasta_indexed
+from fgpyo.io import assert_path_is_readable
+from fgpyo.io import assert_path_is_writable
 
-from divref.alias import HailPath
 from divref.haplotype import get_haplo_sequence
 from divref.haplotype import split_haplotypes
 
@@ -16,14 +20,14 @@ logger = logging.getLogger(__name__)
 
 
 def build_haplotype_table(
-    haplotypes_table_path: HailPath,
-    gnomad_va_file: HailPath,
-    reference_fasta: HailPath,
+    haplotypes_table_path: Path,
+    gnomad_va_file: Path,
+    reference_fasta: Path,
     window_size: int,
     frequency_cutoff: float,
     merge: bool,
     version_str: str,
-    tmp_dir: HailPath,
+    tmp_dir: Path,
 ) -> tuple[hl.Table, list[str]]:
     """
     Build the annotated haplotype table with sequences and variant strings.
@@ -45,8 +49,8 @@ def build_haplotype_table(
     Returns:
         Tuple of (checkpointed Hail table, population legend list).
     """
-    ht = hl.read_table(haplotypes_table_path).key_by()
-    va = hl.read_table(gnomad_va_file)
+    ht = hl.read_table(str(haplotypes_table_path)).key_by()
+    va = hl.read_table(str(gnomad_va_file))
     pops_legend: list[str] = va.pops.collect()[0]
 
     hl.get_reference("GRCh38").add_sequence(reference_fasta)
@@ -132,7 +136,7 @@ def build_haplotype_table(
 
 def export_ht_to_dataframe(
     ht: hl.Table,
-    output_base: HailPath,
+    output_base: Path,
     file_suffix: str,
     pops_legend: list[str],
 ) -> polars.DataFrame:
@@ -148,6 +152,7 @@ def export_ht_to_dataframe(
     Returns:
         Polars DataFrame read back from the exported TSV.
     """
+    out_file_path: str = f"{str(output_base)}{file_suffix}.tsv.bgz"
     ht.select(
         "sequence",
         "sequence_length",
@@ -166,10 +171,10 @@ def export_ht_to_dataframe(
             )
             for i, pop in enumerate(pops_legend)
         },
-    ).export(output_base + f"{file_suffix}.tsv.bgz")
+    ).export(out_file_path)
 
     return polars.read_csv(
-        output_base + f"{file_suffix}.tsv.bgz",
+        out_file_path,
         separator="\t",
         schema_overrides={"sequence_id": polars.String},
     )
@@ -177,7 +182,7 @@ def export_ht_to_dataframe(
 
 def write_fasta_files(
     df: polars.DataFrame,
-    output_base: HailPath,
+    output_base: Path,
     file_suffix: str,
     split_contigs: bool,
 ) -> None:
@@ -195,19 +200,19 @@ def write_fasta_files(
         for chrom in df["contig"].unique().to_list():
             logger.info("Creating FASTA for chromosome %s", chrom)
             df2 = df.filter(df["contig"] == chrom)
-            with open(output_base + f"{file_suffix}.{chrom}.fasta", "w") as fasta_out:
+            with open(f"{str(output_base)}{file_suffix}.{chrom}.fasta", "w") as fasta_out:
                 for sequence, sequence_id in df2.select("sequence", "sequence_id").iter_rows():
                     fasta_out.write(f">{sequence_id}\n{sequence}\n")
     else:
         logger.info("Creating FASTA")
-        with open(output_base + f"{file_suffix}.fasta", "w") as fasta_out:
+        with open(f"{str(output_base)}{file_suffix}.fasta", "w") as fasta_out:
             for sequence, sequence_id in df.select("sequence", "sequence_id").iter_rows():
                 fasta_out.write(f">{sequence_id}\n{sequence}\n")
 
 
 def create_duckdb_index(
     df: polars.DataFrame,  # noqa: ARG001 — accessed by DuckDB via SQL `FROM df`
-    output_base: HailPath,
+    output_base: Path,
     file_suffix: str,
     window_size: int,
     pops_legend: list[str],
@@ -224,7 +229,7 @@ def create_duckdb_index(
         pops_legend: Population legend list to store in the index.
         version_str: Version string to store in the index.
     """
-    duckdb_file = output_base + f"{file_suffix}.index.duckdb"
+    duckdb_file = f"{str(output_base)}{file_suffix}.index.duckdb"
     if os.path.exists(duckdb_file):
         os.remove(duckdb_file)
     con = duckdb.connect(duckdb_file)
@@ -238,16 +243,16 @@ def create_duckdb_index(
 
 def create_fasta_and_index(
     *,
-    haplotypes_table_path: HailPath,
-    gnomad_va_file: HailPath,
-    reference_fasta: HailPath,
+    haplotypes_table_path: Path,
+    gnomad_va_file: Path,
+    reference_fasta: Path,
     window_size: int,
-    output_base: HailPath,
+    output_base: Path,
     version_str: str,
     merge: bool = False,
     frequency_cutoff: float = 0.005,
     split_contigs: bool = False,
-    tmp_dir: HailPath = "/tmp",
+    tmp_dir: Path = Path("/tmp"),
 ) -> None:
     """
     Convert a haplotype Hail table into FASTA sequences and a searchable DuckDB index.
@@ -274,6 +279,13 @@ def create_fasta_and_index(
         split_contigs: If True, write one FASTA file per chromosome.
         tmp_dir: Temporary directory for Hail checkpoint files.
     """
+    assert_directory_exists(haplotypes_table_path)
+    assert_directory_exists(gnomad_va_file)
+    assert_path_is_readable(reference_fasta)
+    assert_fasta_indexed(reference_fasta)
+    assert_path_is_writable(tmp_dir)
+    assert_path_is_writable(output_base)
+
     hl.init(tmp_dir=tmp_dir)
 
     ht, pops_legend = build_haplotype_table(

--- a/divref/divref/tools/create_fasta_and_index.py
+++ b/divref/divref/tools/create_fasta_and_index.py
@@ -15,6 +15,7 @@ from fgpyo.io import assert_path_is_writable
 
 from divref.haplotype import get_haplo_sequence
 from divref.haplotype import split_haplotypes
+from divref import defaults
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +28,7 @@ def build_haplotype_table(
     frequency_cutoff: float,
     merge: bool,
     version_str: str,
+    reference_genome: str,
     tmp_dir: Path,
 ) -> tuple[hl.Table, list[str]]:
     """
@@ -39,11 +41,12 @@ def build_haplotype_table(
     Args:
         haplotypes_table_path: Path to the computed haplotypes Hail table.
         gnomad_va_file: Path to the gnomAD variant annotations Hail table.
-        reference_fasta: Path to the GRCh38 reference FASTA.
+        reference_fasta: Path to the reference FASTA.
         window_size: Context size for sequence construction and haplotype splitting.
         frequency_cutoff: Minimum estimated gnomAD AF for inclusion.
         merge: If True, include gnomAD single-variant sites above frequency_cutoff.
         version_str: Version identifier for sequence IDs.
+        reference_genome: Reference genome to use.
         tmp_dir: Directory for Hail checkpoint files.
 
     Returns:
@@ -53,7 +56,7 @@ def build_haplotype_table(
     va = hl.read_table(str(gnomad_va_file))
     pops_legend: list[str] = va.pops.collect()[0]
 
-    hl.get_reference("GRCh38").add_sequence(reference_fasta)
+    hl.get_reference(reference_genome).add_sequence(reference_fasta)
 
     logger.info(
         "Haplotype table contains %d unique haplotypes above frequency threshold", ht.count()
@@ -252,6 +255,7 @@ def create_fasta_and_index(
     merge: bool = False,
     frequency_cutoff: float = 0.005,
     split_contigs: bool = False,
+    reference_genome: str = defaults.REFERENCE_GENOME,
     tmp_dir: Path = Path("/tmp"),
 ) -> None:
     """
@@ -267,7 +271,7 @@ def create_fasta_and_index(
             (from compute_haplotypes).
         gnomad_va_file: Path to the gnomAD variant annotations Hail table
             (from extract_gnomad_afs).
-        reference_fasta: Path to the GRCh38 reference FASTA for sequence extraction.
+        reference_fasta: Path to the reference FASTA for sequence extraction.
         window_size: Window size used when generating haplotypes; used as the context
             size when constructing sequence strings and stored in the index.
         output_base: Base path for output files. Writes {output_base}.haplotypes.tsv.bgz,
@@ -277,6 +281,7 @@ def create_fasta_and_index(
         merge: If True, include gnomAD single-variant sites above frequency_cutoff.
         frequency_cutoff: Minimum estimated gnomAD allele frequency for haplotype inclusion.
         split_contigs: If True, write one FASTA file per chromosome.
+        reference_genome: Reference genome to use. Defaults to "GRCh38".
         tmp_dir: Temporary directory for Hail checkpoint files.
     """
     assert_directory_exists(haplotypes_table_path)

--- a/divref/divref/tools/create_gnomad_sites_vcf.py
+++ b/divref/divref/tools/create_gnomad_sites_vcf.py
@@ -3,17 +3,15 @@
 from pathlib import Path
 
 import hail as hl
-
-from divref.alias import HailPath
-from divref.hail import hail_init
+from fgpyo.io import assert_directory_exists
+from fgpyo.io import assert_path_is_writable
 
 
 def create_gnomad_sites_vcf(
     *,
-    sites_table_path: HailPath,
-    output_vcf_path: HailPath,
+    sites_table_path: Path,
+    output_vcf_path: Path,
     min_popmax: float,
-    gcs_credentials_path: Path = Path("~/.config/gcloud/application_default_credentials.json"),
 ) -> None:
     """
     Export gnomAD variant sites above a population frequency threshold as VCF.
@@ -27,11 +25,13 @@ def create_gnomad_sites_vcf(
             `extract-gnomad-afs`.
         output_vcf_path: Output path for the VCF file.
         min_popmax: Minimum allele frequency in any population to include a site.
-        gcs_credentials_path: Path to GCS default credentials JSON file.
     """
-    hail_init(gcs_credentials_path.expanduser())
+    assert_directory_exists(sites_table_path)
+    assert_path_is_writable(output_vcf_path)
 
-    ht = hl.read_table(sites_table_path)
+    hl.init()
+
+    ht = hl.read_table(str(sites_table_path))
     pops: list[str] = ht.pops.collect()[0]
 
     filt = ht.filter(hl.max(ht.pop_freqs.map(lambda x: x.AF)) >= min_popmax)
@@ -42,4 +42,4 @@ def create_gnomad_sites_vcf(
             for fd in filt.pop_freqs[i]
         })
     )
-    hl.export_vcf(filt, output_vcf_path)
+    hl.export_vcf(filt, str(output_vcf_path))

--- a/divref/divref/tools/extract_gnomad_afs.py
+++ b/divref/divref/tools/extract_gnomad_afs.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import hail as hl
+from fgpyo.io import assert_path_is_writable
 
 from divref import defaults
 from divref.alias import HailPath
@@ -13,7 +14,7 @@ from divref.haplotype import to_hashable_items
 def extract_gnomad_afs(
     *,
     in_gnomad_sites_table: HailPath,
-    out_variant_annotation_table: HailPath,
+    out_variant_annotation_table: Path,
     contig: str,
     freq_threshold: float = 0.001,
     populations: list[str] = defaults.POPULATIONS,
@@ -36,6 +37,8 @@ def extract_gnomad_afs(
         reference_genome: Reference genome to use. Defaults to "GRCh38".
         gcs_credentials_path: Path to GCS default credentials JSON file.
     """
+    assert_path_is_writable(out_variant_annotation_table)
+
     hail_init(gcs_credentials_path.expanduser())
 
     va_all = hl.read_table(in_gnomad_sites_table)
@@ -58,4 +61,4 @@ def extract_gnomad_afs(
     va = va.select_globals(pops=populations)
     va = va.select(pop_freqs=hl.literal(pop_indices).map(lambda i: va.gnomad_freq[i]))
     va = va.filter(hl.any(lambda x: x.AF > freq_threshold, va.pop_freqs))
-    va.naive_coalesce(64).write(out_variant_annotation_table, overwrite=True)
+    va.naive_coalesce(64).write(str(out_variant_annotation_table), overwrite=True)

--- a/divref/divref/tools/extract_sample_metadata.py
+++ b/divref/divref/tools/extract_sample_metadata.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import hail as hl
+from fgpyo.io import assert_path_is_writable
 
 from divref.alias import HailPath
 from divref.hail import hail_init
@@ -11,7 +12,7 @@ from divref.hail import hail_init
 def extract_sample_metadata(
     *,
     in_gnomad_hgdp_sample_data: HailPath,
-    out_sample_metadata: HailPath,
+    out_sample_metadata: Path,
     gcs_credentials_path: Path = Path("~/.config/gcloud/application_default_credentials.json"),
 ) -> None:
     """
@@ -22,8 +23,10 @@ def extract_sample_metadata(
         out_sample_metadata: Output path for the sample metadata Hail table.
         gcs_credentials_path: Path to GCS default credentials JSON file.
     """
+    assert_path_is_writable(out_sample_metadata)
+
     hail_init(gcs_credentials_path.expanduser())
 
     sa = hl.read_table(in_gnomad_hgdp_sample_data).select_globals()
     sa = sa.select(pop=sa.gnomad_population_inference.pop)
-    sa.naive_coalesce(4).write(out_sample_metadata, overwrite=True)
+    sa.naive_coalesce(4).write(str(out_sample_metadata), overwrite=True)

--- a/divref/divref/tools/gnomad_hail_table_test_data.py
+++ b/divref/divref/tools/gnomad_hail_table_test_data.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 
 import hail as hl
+from fgpyo.io import assert_path_is_writable
 
 from divref import defaults
 from divref.alias import HailPath
@@ -16,8 +17,8 @@ def gnomad_hail_table_test_data(
     *,
     in_gnomad_hgdp_variant_annotation_table: HailPath = defaults.GNOMAD_HGDP_1KG_VARIANT_ANNOTATION_HAIL_TABLE,  # noqa: E501
     in_gnomad_hgdp_sample_metadata: HailPath = defaults.GNOMAD_HGDP_1KG_SAMPLE_METADATA_HAIL_TABLE,  # noqa: E501
-    out_variant_annotation_table: HailPath,
-    out_sample_metadata: HailPath,
+    out_variant_annotation_table: Path,
+    out_sample_metadata: Path,
     locus: str = "chr1:100001-200000",
     gcs_credentials_path: Path = Path("~/.config/gcloud/application_default_credentials.json"),
 ) -> None:
@@ -34,6 +35,9 @@ def gnomad_hail_table_test_data(
         locus: Locus interval for variant filtering.
         gcs_credentials_path: Path to GCS default credentials JSON file.
     """
+    assert_path_is_writable(out_variant_annotation_table)
+    assert_path_is_writable(out_sample_metadata)
+
     hail_init(gcs_credentials_path.expanduser())
 
     va = hl.read_table(in_gnomad_hgdp_variant_annotation_table)

--- a/divref/pyproject.toml
+++ b/divref/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.12,<3.14"
 dependencies    = [
     "defopt~=6.4",
     "duckdb>=1.0",
+    "fgmetric>=0.2.0",
     "fgpyo>=1.5.1",
     "hail>=0.2",
     "pandas>=2.0",

--- a/divref/pyproject.toml
+++ b/divref/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.12,<3.14"
 dependencies    = [
     "defopt~=6.4",
     "duckdb>=1.0",
+    "fgpyo>=1.5.1",
     "hail>=0.2",
     "pandas>=2.0",
     "polars>=1.0",

--- a/divref/tests/test_haplotype.py
+++ b/divref/tests/test_haplotype.py
@@ -140,14 +140,17 @@ def test_get_haplo_sequence_empty_tuple_raises() -> None:
 
 
 def test_to_hashable_items_empty() -> None:
+    """to_hashable_items should return an empty tuple for an empty dict."""
     assert to_hashable_items({}) == ()
 
 
 def test_to_hashable_items_single_entry() -> None:
+    """to_hashable_items should return a one-element tuple for a single-entry dict."""
     assert to_hashable_items({"key": "value"}) == (("key", "value"),)
 
 
 def test_to_hashable_items_sorted_by_key() -> None:
+    """to_hashable_items should return items sorted by key regardless of insertion order."""
     assert to_hashable_items({"b": 2, "a": 1, "c": 3}) == (("a", 1), ("b", 2), ("c", 3))
 
 
@@ -157,21 +160,21 @@ def test_to_hashable_items_sorted_by_key() -> None:
 
 
 def test_variant_distance_adjacent_snps(hail_context: None) -> None:  # noqa: ARG001
-    # SNP at 100, next SNP at 101: distance = 101 - 100 - len("A") = 0
+    """SNP at 100, next SNP at 101: distance = 101 - 100 - len("A") = 0."""
     assert (
         hl.eval(variant_distance(_make_variant(100, "A", "T"), _make_variant(101, "C", "G"))) == 0
     )
 
 
 def test_variant_distance_snps_with_gap(hail_context: None) -> None:  # noqa: ARG001
-    # SNP at 100, next SNP at 103: 2 reference bases separate them
+    """SNP at 100, next SNP at 103: 2 reference bases separate them."""
     assert (
         hl.eval(variant_distance(_make_variant(100, "A", "T"), _make_variant(103, "C", "G"))) == 2
     )
 
 
 def test_variant_distance_deletion_closes_gap(hail_context: None) -> None:  # noqa: ARG001
-    # Deletion AT→A at 100 (consumes 2 ref bases), next variant at 102: distance = 0
+    """Deletion AT→A at 100 (consumes 2 ref bases), next variant at 102: distance = 0."""
     assert (
         hl.eval(variant_distance(_make_variant(100, "AT", "A"), _make_variant(102, "C", "G"))) == 0
     )
@@ -183,7 +186,7 @@ def test_variant_distance_deletion_closes_gap(hail_context: None) -> None:  # no
 
 
 def test_split_haplotypes_no_split_needed(hail_context: None) -> None:  # noqa: ARG001
-    # All variants within window_size=200; haplotype is kept intact as one row
+    """All variants within window_size=200; haplotype is kept intact as one row."""
     ht = _make_haplotype_table([
         ("chr1", 100, "A", "T"),
         ("chr1", 150, "C", "G"),
@@ -195,8 +198,11 @@ def test_split_haplotypes_no_split_needed(hail_context: None) -> None:  # noqa: 
 
 
 def test_split_haplotypes_splits_at_large_gap(hail_context: None) -> None:  # noqa: ARG001
-    # Gap between positions 101 and 500 (398 bases) exceeds window_size=200;
-    # results in two sub-haplotypes: [v0, v1] and [v2, v3]
+    """
+    Gap between positions 101 and 500 (398 bases) exceeds window_size=200.
+
+    Results in two sub-haplotypes: [v0, v1] and [v2, v3].
+    """
     ht = _make_haplotype_table([
         ("chr1", 100, "A", "T"),
         ("chr1", 101, "C", "G"),
@@ -213,8 +219,11 @@ def test_split_haplotypes_splits_at_large_gap(hail_context: None) -> None:  # no
 
 
 def test_split_haplotypes_discards_singleton_segment(hail_context: None) -> None:  # noqa: ARG001
-    # Gap after position 100 isolates it as a singleton (discarded);
-    # only the two-variant segment [500, 501] is kept
+    """
+    Gap after position 100 isolates it as a singleton (discarded).
+
+    Only the two-variant segment [500, 501] is kept.
+    """
     ht = _make_haplotype_table([
         ("chr1", 100, "A", "T"),
         ("chr1", 500, "C", "G"),

--- a/divref/tests/tools/test_compute_haplotypes.py
+++ b/divref/tests/tools/test_compute_haplotypes.py
@@ -28,7 +28,7 @@ def test_compute_haplotypes(
             window_size=5000,
             freq_threshold=0.005,
             output_base=output_base,
-            temp_dir=str(tmp_path / "hail_tmp"),
+            temp_dir=tmp_path / "hail_tmp",
         )
 
     # --- assert ---

--- a/divref/tests/tools/test_compute_haplotypes.py
+++ b/divref/tests/tools/test_compute_haplotypes.py
@@ -15,10 +15,10 @@ def test_compute_haplotypes(
 ) -> None:
     """Happy-path: compute haplotypes from test VCF with gnomAD annotations."""
     # --- act ---
-    in_sites = str(datadir / "chr1_100001_200000.gnomad_afs.ht")
-    in_samples = str(datadir / "hgdp_1kg_sample_metadata.extract.ht")
-    vcf_path = str(datadir / "chr1_100001_200000.vcf.gz")
-    output_base = str(tmp_path / "haplos")
+    in_sites = datadir / "chr1_100001_200000.gnomad_afs.ht"
+    in_samples = datadir / "hgdp_1kg_sample_metadata.extract.ht"
+    vcf_path = datadir / "chr1_100001_200000.vcf.gz"
+    output_base = tmp_path / "haplos"
 
     with patch("divref.tools.compute_haplotypes.hl.init"):
         compute_haplotypes(

--- a/divref/tests/tools/test_create_gnomad_sites_vcf.py
+++ b/divref/tests/tools/test_create_gnomad_sites_vcf.py
@@ -16,10 +16,10 @@ def test_create_gnomad_sites_vcf(
 ) -> None:
     """Happy-path: filter extracted AFs and export as VCF."""
     # --- act: run create_gnomad_sites_vcf ---
-    in_sites = str(datadir / "chr1_100001_200000.gnomad_afs.ht")
-    output_vcf = str(tmp_path / "output.vcf.bgz")
+    in_sites = datadir / "chr1_100001_200000.gnomad_afs.ht"
+    output_vcf = tmp_path / "output.vcf.bgz"
 
-    with patch("divref.tools.create_gnomad_sites_vcf.hail_init"):
+    with patch("divref.tools.create_gnomad_sites_vcf.hl.init"):
         create_gnomad_sites_vcf(
             sites_table_path=in_sites,
             output_vcf_path=output_vcf,
@@ -27,7 +27,7 @@ def test_create_gnomad_sites_vcf(
         )
 
     # --- assert: VCF file is valid ---
-    vcf = hl.import_vcf(output_vcf, reference_genome=defaults.REFERENCE_GENOME)
+    vcf = hl.import_vcf(str(output_vcf), reference_genome=defaults.REFERENCE_GENOME)
     vcf_count = vcf.count_rows()
     assert vcf_count == 333
 
@@ -39,5 +39,5 @@ def test_create_gnomad_sites_vcf(
         )
 
     # VCF should have equal or fewer variants than the unfiltered extracted table
-    va = hl.read_table(in_sites)
+    va = hl.read_table(str(in_sites))
     assert vcf_count <= va.count()

--- a/divref/tests/tools/test_extract_gnomad_afs.py
+++ b/divref/tests/tools/test_extract_gnomad_afs.py
@@ -16,7 +16,7 @@ def test_extract_gnomad_afs(
 ) -> None:
     """Happy-path: extract AFs from local test variant and sample data."""
     in_sites = str(datadir / "chr1_100001_200000.ht")
-    out_va = str(tmp_path / "va.ht")
+    out_va = tmp_path / "va.ht"
 
     with patch("divref.tools.extract_gnomad_afs.hail_init"):
         extract_gnomad_afs(
@@ -28,7 +28,7 @@ def test_extract_gnomad_afs(
             reference_genome=defaults.REFERENCE_GENOME,
         )
 
-    va = hl.read_table(out_va)
+    va = hl.read_table(str(out_va))
     va_count = va.count()
     assert va_count == 966
 

--- a/divref/tests/tools/test_extract_sample_metadata.py
+++ b/divref/tests/tools/test_extract_sample_metadata.py
@@ -15,7 +15,7 @@ def test_extract_sample_metadata(
 ) -> None:
     """Happy-path: extract sample metadata from local test data."""
     in_samples = str(datadir / "hgdp_1kg_sample_metadata.ht")
-    out_sa = str(tmp_path / "sa.ht")
+    out_sa = tmp_path / "sa.ht"
 
     with patch("divref.tools.extract_sample_metadata.hail_init"):
         extract_sample_metadata(
@@ -23,7 +23,7 @@ def test_extract_sample_metadata(
             out_sample_metadata=out_sa,
         )
 
-    sa = hl.read_table(out_sa)
+    sa = hl.read_table(str(out_sa))
     sa_count = sa.count()
     assert sa_count == 4151
 

--- a/divref/tests/tools/test_remap_divref.py
+++ b/divref/tests/tools/test_remap_divref.py
@@ -67,9 +67,12 @@ def create_haplotype(
 
 
 def test_basic_snp_variants_involved() -> None:
-    # With context_size=10, haplotype sequence pos 0 = reference pos 490.
-    # Variants at ref positions 500, 505, 510 map to haplotype positions 10, 15, 20.
-    # Query window [12, 17) overlaps only the second variant (pos 15..16).
+    """
+    With context_size=10, haplotype pos 0 = reference pos 490.
+
+    Variants at ref positions 500, 505, 510 map to haplotype positions 10, 15, 20.
+    Query window [12, 17) overlaps only the second variant (pos 15..16).
+    """
     haplotype = create_haplotype(sequence_id="hap1", variants="1:500:A:T,1:505:C:G,1:510:T:A")
     rm: ReferenceMapping = haplotype.reference_mapping(12, 17, 10)
 
@@ -85,8 +88,11 @@ def test_basic_snp_variants_involved() -> None:
 
 
 def test_deletion_shifts_coordinates() -> None:
-    # Second variant is a deletion (CC→G), which shifts subsequent haplotype positions.
-    # Query [14, 20) spans the deletion and the following SNP.
+    """
+    Second variant is a deletion (CC→G), which shifts subsequent haplotype positions.
+
+    Query [14, 20) spans the deletion and the following SNP.
+    """
     haplotype = create_haplotype(sequence_id="hap2", variants="1:500:A:T,1:505:CC:G,1:510:T:A")
     rm = haplotype.reference_mapping(14, 20, 10)
 
@@ -95,8 +101,11 @@ def test_deletion_shifts_coordinates() -> None:
 
 
 def test_insertion_shifts_coordinates() -> None:
-    # First variant is an insertion (T→TTT), which shifts subsequent haplotype positions.
-    # Query [15, 18) lands in the expanded haplotype space after the insertion.
+    """
+    First variant is an insertion (T→TTT), which shifts subsequent haplotype positions.
+
+    Query [15, 18) lands in the expanded haplotype space after the insertion.
+    """
     haplotype = create_haplotype(sequence_id="hap3", variants="1:500:T:TTT,1:505:C:G,1:510:T:A")
     rm = haplotype.reference_mapping(15, 18, 10)
 
@@ -105,7 +114,7 @@ def test_insertion_shifts_coordinates() -> None:
 
 
 def test_no_variants_in_range() -> None:
-    # Query [0, 5) is entirely in the flanking context before any variant.
+    """Query [0, 5) is entirely in the flanking context before any variant."""
     haplotype = create_haplotype(sequence_id="hap4", variants="1:500:A:T,1:510:C:G")
     rm = haplotype.reference_mapping(0, 5, 10)
 
@@ -114,7 +123,7 @@ def test_no_variants_in_range() -> None:
 
 
 def test_complex_multi_indel_mapping() -> None:
-    # Three variants: deletion, insertion, deletion. Query [9, 22) spans all three.
+    """Three variants: deletion, insertion, deletion. Query [9, 22) spans all three."""
     haplotype = create_haplotype(
         sequence_id="hap5",
         variants="1:500:AT:A,1:505:C:CTT,1:510:GGG:T",
@@ -131,9 +140,12 @@ def test_complex_multi_indel_mapping() -> None:
 
 
 def test_large_insertion_with_null_frequencies() -> None:
-    # Single large insertion. null gnomAD frequencies should be parsed as 0.0.
-    # context_size=25, variant at ref pos 90349349.
-    # Query [22, 42) starts before the insertion (ref start = 90349349 - 3 = 90349346).
+    """
+    Single large insertion; null gnomAD frequencies should be parsed as 0.0.
+
+    context_size=25, variant at ref pos 90349349.
+    Query [22, 42) starts before the insertion (ref start = 90349349 - 3 = 90349346).
+    """
     alt = "TATGCAAGTGTCATCAGATGAATTGATGACATTTTTGTCAAGTTTAAGCACTGAAAGAACAAACCTCTAAATC"
     haplotype = create_haplotype(
         sequence_id="hap6",
@@ -168,18 +180,21 @@ def test_large_insertion_with_null_frequencies() -> None:
 
 
 def test_variant_render_snp() -> None:
+    """Variant.render should format a SNP as 'chr:pos:ref:alt'."""
     assert Variant(chromosome="chr1", position=100, reference="A", alternate="T").render() == (
         "chr1:100:A:T"
     )
 
 
 def test_variant_render_insertion() -> None:
+    """Variant.render should format an insertion as 'chr:pos:ref:alt'."""
     assert Variant(chromosome="chr2", position=200, reference="A", alternate="ATG").render() == (
         "chr2:200:A:ATG"
     )
 
 
 def test_variant_render_deletion() -> None:
+    """Variant.render should format a deletion as 'chr:pos:ref:alt'."""
     assert Variant(chromosome="chrX", position=300, reference="ATG", alternate="A").render() == (
         "chrX:300:ATG:A"
     )
@@ -191,6 +206,7 @@ def test_variant_render_deletion() -> None:
 
 
 def test_parsed_variants_single() -> None:
+    """parsed_variants should parse a single variant string into one Variant."""
     hap = create_haplotype(variants="chr1:100:A:T", n_variants=1)
     vs = hap.parsed_variants()
     assert len(vs) == 1
@@ -201,6 +217,7 @@ def test_parsed_variants_single() -> None:
 
 
 def test_parsed_variants_multiple() -> None:
+    """parsed_variants should parse multiple comma-separated variants."""
     hap = create_haplotype(variants="chr1:100:A:T,chr1:200:CC:G", n_variants=2)
     vs = hap.parsed_variants()
     assert len(vs) == 2
@@ -209,12 +226,13 @@ def test_parsed_variants_multiple() -> None:
 
 
 def test_parsed_variants_cached() -> None:
-    # Second call returns the exact same list object (no re-parsing)
+    """Second call to parsed_variants returns the exact same list object (no re-parsing)."""
     hap = create_haplotype(variants="chr1:100:A:T,chr1:200:C:G", n_variants=2)
     assert hap.parsed_variants() is hap.parsed_variants()
 
 
 def test_contig_returns_first_variant_chromosome() -> None:
+    """Contig should return the chromosome of the first parsed variant."""
     hap = create_haplotype(variants="chr5:100:A:T,chr5:200:C:G", n_variants=2)
     assert hap.contig() == "chr5"
 
@@ -225,6 +243,7 @@ def test_contig_returns_first_variant_chromosome() -> None:
 
 
 def test_variants_involved_str_empty() -> None:
+    """variants_involved_str should return an empty string when no variants are involved."""
     rm = ReferenceMapping(
         chromosome="chr1",
         start=100,
@@ -238,6 +257,7 @@ def test_variants_involved_str_empty() -> None:
 
 
 def test_variants_involved_str_single() -> None:
+    """variants_involved_str should return a single rendered variant string."""
     rm = ReferenceMapping(
         chromosome="chr1",
         start=100,
@@ -251,6 +271,7 @@ def test_variants_involved_str_single() -> None:
 
 
 def test_variants_involved_str_multiple() -> None:
+    """variants_involved_str should return comma-separated rendered variant strings."""
     rm = ReferenceMapping(
         chromosome="chr1",
         start=100,
@@ -272,14 +293,17 @@ def test_variants_involved_str_multiple() -> None:
 
 
 def test_parse_pop_freqs_all_floats() -> None:
+    """_parse_pop_freqs should parse a comma-separated string of floats."""
     assert _parse_pop_freqs("0.1,0.2,0.3") == [0.1, 0.2, 0.3]
 
 
 def test_parse_pop_freqs_nulls_become_zero() -> None:
+    """_parse_pop_freqs should replace 'null' entries with 0.0."""
     assert _parse_pop_freqs("0.1,null,0.3") == [0.1, 0.0, 0.3]
 
 
 def test_parse_pop_freqs_single_null() -> None:
+    """_parse_pop_freqs should return [0.0] for a single 'null' entry."""
     assert _parse_pop_freqs("null") == [0.0]
 
 
@@ -289,21 +313,21 @@ def test_parse_pop_freqs_single_null() -> None:
 
 
 def test_parsed_variants_empty_string_raises() -> None:
-    # variants="" yields one empty token which cannot be split into 4 fields.
+    """variants="" yields one empty token which cannot be split into 4 fields."""
     hap = create_haplotype(variants="", n_variants=0)
     with pytest.raises(ValueError):
         hap.parsed_variants()
 
 
 def test_parsed_variants_too_few_fields_raises() -> None:
-    # "chr1:100:A" has only 3 colon-delimited fields; unpacking into 4 raises ValueError.
+    """'chr1:100:A' has only 3 colon-delimited fields; unpacking into 4 raises ValueError."""
     hap = create_haplotype(variants="chr1:100:A", n_variants=1)
     with pytest.raises(ValueError):
         hap.parsed_variants()
 
 
 def test_contig_malformed_variants_raises() -> None:
-    # contig() delegates to parsed_variants(), so a malformed string propagates the error.
+    """contig() delegates to parsed_variants(), so a malformed string propagates the error."""
     hap = create_haplotype(variants="", n_variants=0)
     with pytest.raises(ValueError):
         hap.contig()

--- a/divref/tests/tools/test_rewrite_fasta.py
+++ b/divref/tests/tools/test_rewrite_fasta.py
@@ -12,18 +12,21 @@ def _write_fasta(path: Path, contigs: list[tuple[str, str]]) -> None:
 
 
 def test_keeps_canonical_autosomes(tmp_path: Path) -> None:
+    """rewrite_fasta should retain canonical autosomes (chr1–chr22) in the output."""
     _write_fasta(tmp_path / "in.fa", [("chr1", "ACGT"), ("chr22", "TTTT")])
     rewrite_fasta(fasta_path=tmp_path / "in.fa", output_path=tmp_path / "out.fa")
     assert (tmp_path / "out.fa").read_text() == ">chr1\nACGT\n>chr22\nTTTT\n"
 
 
 def test_keeps_sex_and_mt_chromosomes(tmp_path: Path) -> None:
+    """rewrite_fasta should retain sex chromosomes (chrX, chrY) and mitochondrial (chrMT)."""
     _write_fasta(tmp_path / "in.fa", [("chrX", "AAAA"), ("chrY", "CCCC"), ("chrMT", "GGGG")])
     rewrite_fasta(fasta_path=tmp_path / "in.fa", output_path=tmp_path / "out.fa")
     assert (tmp_path / "out.fa").read_text() == ">chrX\nAAAA\n>chrY\nCCCC\n>chrMT\nGGGG\n"
 
 
 def test_filters_non_canonical(tmp_path: Path) -> None:
+    """rewrite_fasta should filter out non-canonical contigs (alt, unlocalized, unplaced)."""
     _write_fasta(
         tmp_path / "in.fa",
         [("chr1", "ACGT"), ("chr1_alt", "AAAA"), ("chrUn_gl000220", "TTTT")],
@@ -33,6 +36,7 @@ def test_filters_non_canonical(tmp_path: Path) -> None:
 
 
 def test_mixed_canonical_and_non_canonical(tmp_path: Path) -> None:
+    """rewrite_fasta should keep only canonical contigs when mixed with non-canonical ones."""
     _write_fasta(
         tmp_path / "in.fa",
         [("chr1", "ACGT"), ("chr1_alt", "AAAA"), ("chr2", "TTTT"), ("chrEBV", "CCCC")],
@@ -42,12 +46,14 @@ def test_mixed_canonical_and_non_canonical(tmp_path: Path) -> None:
 
 
 def test_empty_fasta(tmp_path: Path) -> None:
+    """rewrite_fasta should produce an empty output file for an empty input FASTA."""
     (tmp_path / "in.fa").write_text("")
     rewrite_fasta(fasta_path=tmp_path / "in.fa", output_path=tmp_path / "out.fa")
     assert (tmp_path / "out.fa").read_text() == ""
 
 
 def test_multiline_sequence_preserved(tmp_path: Path) -> None:
+    """rewrite_fasta should preserve multi-line sequences for canonical contigs."""
     (tmp_path / "in.fa").write_text(">chr1\nACGT\nTGCA\n>chr1_alt\nAAAA\n")
     rewrite_fasta(fasta_path=tmp_path / "in.fa", output_path=tmp_path / "out.fa")
     assert (tmp_path / "out.fa").read_text() == ">chr1\nACGT\nTGCA\n"

--- a/divref/uv.lock
+++ b/divref/uv.lock
@@ -559,6 +559,7 @@ source = { editable = "." }
 dependencies = [
     { name = "defopt" },
     { name = "duckdb" },
+    { name = "fgpyo" },
     { name = "hail" },
     { name = "pandas" },
     { name = "polars" },
@@ -583,6 +584,7 @@ ipython = [
 requires-dist = [
     { name = "defopt", specifier = "~=6.4" },
     { name = "duckdb", specifier = ">=1.0" },
+    { name = "fgpyo", specifier = ">=1.5.1" },
     { name = "hail", specifier = ">=0.2" },
     { name = "pandas", specifier = ">=2.0" },
     { name = "polars", specifier = ">=1.0" },
@@ -639,6 +641,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "fgpyo"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "pysam" },
+    { name = "strenum" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "zlib-ng" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/8b/fed281bb5b2854d0c5e5c0b24f4bea5ff81c8d2422cdbd8e91dfad96e591/fgpyo-1.5.1.tar.gz", hash = "sha256:6e2b5d0d5b7f3d5909db849e2ed0c4f08cd4eb11e9809b693fe331f430657f53", size = 195935, upload-time = "2026-03-30T18:49:13.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/28/b363f21ca15ef86c8ee4c147b2831852c80b218e0616e0aec02f829eee26/fgpyo-1.5.1-py3-none-any.whl", hash = "sha256:0de80c20929fe9e249841f419f31d7ae11bf3a3919e7bd0f576d1b88259eb12c", size = 78841, upload-time = "2026-03-30T18:49:11.92Z" },
 ]
 
 [[package]]
@@ -1636,6 +1654,26 @@ crypto = [
 ]
 
 [[package]]
+name = "pysam"
+version = "0.23.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2b/1cf19890a0e4c73ad2672ce7eb485606c4bd2846eef2d892c078ab193c92/pysam-0.23.3.tar.gz", hash = "sha256:9ebcb1f004b296fd139b103ec6fd7e415e80f89f194eb7d0d972ac6d11bbaf24", size = 4974405, upload-time = "2025-06-10T11:19:54.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/6b/dd9f94da44463ecfddb7075f1048c044155c725d7d79fde2e7957561a3b0/pysam-0.23.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:69f90c0867fe43f04004bcea963f6b2e68b39180afab54bf551f61f43856638b", size = 6177042, upload-time = "2025-06-10T11:19:19.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e9/686e711a559a02e4c3ba0bc78cf031d9ddb525e9f0b2984d1b66536ba94a/pysam-0.23.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2310d72bfae7a0980d414156267e25b57aa221a768c11c087f3f7d00ceb9fed4", size = 8398187, upload-time = "2025-06-10T11:22:52.284Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/82/fca396e13969d1020956b02e567e0d357be0af0f3aebc2b4d97bed780a6d/pysam-0.23.3-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b2e45983efea190d374fcda0b6e0c835d6e9e474e02694729f3b3a14d680fa62", size = 23343831, upload-time = "2025-06-10T11:22:54.594Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a6/c100df6c8118b4ce1f9c086bb9cf5bccd4f71d05ceb2ecf474f3b0ea87b8/pysam-0.23.3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4099393fc5097b5081c7efaf46b0109e4f0a8ed18f86d497219a8bf739c73992", size = 24021198, upload-time = "2025-06-10T11:19:21.379Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/92/32e1b13f30f16fe2c948f9b9e04c6e7698beaa539ea1a2bcddc51ed6c9b7/pysam-0.23.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4f04b9aa9b23d767fe36652eacb8370791e3b56816a7e50553d52c65ccdce77f", size = 22925815, upload-time = "2025-06-10T11:22:56.894Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7d/ccfaa2d6f9f07b357696b07883d5c5471f980938c2293324631425d95523/pysam-0.23.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:701843e5dc67c8eb217c3265039c699a5f83cce64fbc4225268141796e972353", size = 23351352, upload-time = "2025-06-10T11:19:24.207Z" },
+    { url = "https://files.pythonhosted.org/packages/88/87/55cabf614bcc96f4a548ab4cf5fe465dd562d193f4f4cd5246cc0a1a18ab/pysam-0.23.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2d3177c5b3e102bde297f86e079d23fa385ac88f16c4252502079ef368056d55", size = 8660576, upload-time = "2025-06-10T11:19:26.918Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/2f/4708f52028610af96fa82e3ef46bcf96a35f1bd3c38aa6f015b31b578fff/pysam-0.23.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2b6f6891684213e89ee679c5ac786b4e845e7d39d24f6ea0e4d8ed8be9c34f48", size = 8420107, upload-time = "2025-06-10T11:22:59.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/35/e65f76cfa17d680017bbb61f2a2b3ad34169de5c3747ed4273c194ad13b3/pysam-0.23.3-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:735b938b809f0dc19a389cf3cee04fe7a451e21e2b20d3e45fa6bc23016ae21d", size = 26547806, upload-time = "2025-06-10T11:23:02.083Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/60/2c8574f13f5a9c07cc14f5b48f70591fcd1ccb50dd59ad9784d48ed31db4/pysam-0.23.3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:b721ae4c9118e0c27e1500be278c3b62022c886eeb913ecabc0463fdf98da38f", size = 27262067, upload-time = "2025-06-10T11:19:29.222Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ef/6ca22f37b3c771f5df38a533d8276dabaacc89a034341a0ec33b7ec21d5e/pysam-0.23.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:915bd2883eed08b16a41964a33923818e67166ca69a51086598d27287df6bb4f", size = 26036767, upload-time = "2025-06-10T11:23:04.839Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a4/d52ac0f89fa90ab98998e5c0640963f3f4c1e9703fd4dd0aaa4facaea187/pysam-0.23.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b80f1092ba290b738d6ed230cc58cc75ca815fda441afe76cb4c25639aec7ee7", size = 26477588, upload-time = "2025-06-10T11:19:31.96Z" },
+]
+
+[[package]]
 name = "pyspark"
 version = "3.5.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1975,6 +2013,15 @@ wheels = [
 ]
 
 [[package]]
+name = "strenum"
+version = "0.4.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/ad/430fb60d90e1d112a62ff57bdd1f286ec73a2a0331272febfddd21f330e1/StrEnum-0.4.15.tar.gz", hash = "sha256:878fb5ab705442070e4dd1929bb5e2249511c0bcf2b0eeacf3bcd80875c82eff", size = 23384, upload-time = "2023-06-29T22:02:58.399Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl", hash = "sha256:a30cda4af7cc6b5bf52c8055bc4bf4b2b6b14a93b574626da33df53cf7740659", size = 8851, upload-time = "2023-06-29T22:02:56.947Z" },
+]
+
+[[package]]
 name = "tabulate"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2217,4 +2264,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/43/68/8c5b36aa5178900b37387937bc2c2fe0e9505537f713495472dcf6f6fccc/yarl-1.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dd00607bffbf30250fe108065f07453ec124dbf223420f57f5e749b04295e090", size = 94932, upload-time = "2026-03-01T22:06:39.579Z" },
     { url = "https://files.pythonhosted.org/packages/c6/cc/d79ba8292f51f81f4dc533a8ccfb9fc6992cabf0998ed3245de7589dc07c/yarl-1.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:ac09d42f48f80c9ee1635b2fcaa819496a44502737660d3c0f2ade7526d29144", size = 84786, upload-time = "2026-03-01T22:06:41.988Z" },
     { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
+]
+
+[[package]]
+name = "zlib-ng"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/7d/901c6e333fb031b5bfbd1532099200cf859f12aa83689be494eade6685ec/zlib_ng-1.0.0.tar.gz", hash = "sha256:c753cea73f9e803c246e9bf01a59eb652897ed8a19334ada0f968394c7f61650", size = 5799954, upload-time = "2025-09-10T11:46:17.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/6f/ad3b032d3881a5f35d673b429a8a524d8cb2b56d81f8ca4194117a502509/zlib_ng-1.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d894ed89fd1f53344b8334333794f53d7119da034b49e08e39f0d2b05a1f699c", size = 108672, upload-time = "2025-09-10T11:45:18.222Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/7c/67d4a0bb72039f8a8e11cd711aed63a0adf83961fea668e204b07d6f469d/zlib_ng-1.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c01e44613d9a4cc1f6f6dcfab03ae43fd3b4f9bd909006398c75fe4a1fb48333", size = 91299, upload-time = "2025-09-10T11:43:55.018Z" },
+    { url = "https://files.pythonhosted.org/packages/50/97/9836a0ec483786803c1a9925f6249cbb5dbd408fcc100bd8b4cd615c012d/zlib_ng-1.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:611a85b2dcb206a3cf8cdaa4323dbf9dbefe6c92e83d2da86333050f33a4318e", size = 111319, upload-time = "2025-09-10T12:21:23.809Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ed/5baf549131c47cbf5a00c35c7db7a78d5aa3c405605255a1496160a96a87/zlib_ng-1.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5332f9452b2fc27e47a1ca78fc150689ed9c51c7f449a5467bf41c4b206c439f", size = 132407, upload-time = "2025-09-10T11:46:07.343Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e6/6b09e61cfa205b546f3c8202be35795040340a12dde36dd990eac9747ef8/zlib_ng-1.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6c362f54b67a4385b19ab8972b66f34da73b93c1b8f0b251a0f20d315c15f71a", size = 112144, upload-time = "2025-09-10T12:21:24.995Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/55/886fe76443fb7131a364a4ff3b257ac0c7bcf61d2562c009de5104a051d9/zlib_ng-1.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e1a1205e4146819f9c5dbaaa89be587fc7a09f06094676f2dc27146ba1682de5", size = 133232, upload-time = "2025-09-10T11:46:08.21Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c7/b6684511acc5e026650e98e029b34fa801750d29654172a1d651f619d348/zlib_ng-1.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:c6e16cb8cb140bc3e76f95294f91939929a0a3fcc0fbb6ba4191fc24dc15dea9", size = 93520, upload-time = "2025-09-10T11:54:57.879Z" },
+    { url = "https://files.pythonhosted.org/packages/29/87/70b3c49c0468505cf333a9027c03b2c70f169dc6c0f4cc4d0a4ddbe38875/zlib_ng-1.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:79b172c6046d8be48500e95e3b6858056a8dfeb95c57d0403c6e7e874bcb87d9", size = 108682, upload-time = "2025-09-10T11:45:19.009Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/eb/293e0f4b1598a82972cb45aa80c0b2cac88f6b0f7877081e77aba1abe668/zlib_ng-1.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8da943c739ffc86679979dcb654294e6bf7d40829de7dca43d453b46b251435c", size = 91290, upload-time = "2025-09-10T11:43:56.252Z" },
+    { url = "https://files.pythonhosted.org/packages/77/61/a93b686a3f2dc3c0a44a193757e8ca852f34fac64939f6bbe0c65928f7a6/zlib_ng-1.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:377dd5ee851e8fea0f81811866eb0463d3e7c781d4c5fd89401ef69036befce3", size = 111303, upload-time = "2025-09-10T12:21:26.286Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/15/90ef47172106a3c56697907c048bffc14529c09c8785716ba296d27f0e4e/zlib_ng-1.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e7a8baaa2c766c6ae60417612ce2d8cd08555596662d6b4b5c594095dffaed5", size = 132395, upload-time = "2025-09-10T11:46:09.462Z" },
+    { url = "https://files.pythonhosted.org/packages/61/f1/fe005fda8cee96c6ea4a4070d7ebbabf91f65930a750f2af4529ff36db85/zlib_ng-1.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fef21e3c5528e008ac4fc7932d373ba9854090830731db9051c2a9344ae26579", size = 112122, upload-time = "2025-09-10T12:21:27.38Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/2d/61b61146fcb8ccd529a0e73818c8a7f6ecdd5fb0a2c4c3be32c9a9397845/zlib_ng-1.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4c30a1c8394d9c48fd9c5290355d00b6fd06f661b3c454d1747c62269e917cdd", size = 133219, upload-time = "2025-09-10T11:46:10.656Z" },
+    { url = "https://files.pythonhosted.org/packages/96/cc/255bf0e3098ff31690fa4ab73606330abd9e2f8f260999938456dd450fed/zlib_ng-1.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:6ecf6ab9b7cb31ae192f469d7f1bcc1cae8314c7baf78bb174d43eb9a6e73f0d", size = 93525, upload-time = "2025-09-10T11:54:58.731Z" },
 ]

--- a/divref/uv.lock
+++ b/divref/uv.lock
@@ -559,6 +559,7 @@ source = { editable = "." }
 dependencies = [
     { name = "defopt" },
     { name = "duckdb" },
+    { name = "fgmetric" },
     { name = "fgpyo" },
     { name = "hail" },
     { name = "pandas" },
@@ -584,6 +585,7 @@ ipython = [
 requires-dist = [
     { name = "defopt", specifier = "~=6.4" },
     { name = "duckdb", specifier = ">=1.0" },
+    { name = "fgmetric", specifier = ">=0.2.0" },
     { name = "fgpyo", specifier = ">=1.5.1" },
     { name = "hail", specifier = ">=0.2" },
     { name = "pandas", specifier = ">=2.0" },
@@ -641,6 +643,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "fgmetric"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/b4/edb1f6dfc3321620dfe02125ce20a4708805b9c2eb7d3ea57c2bce641662/fgmetric-0.2.0.tar.gz", hash = "sha256:cf0ad030f0d4d3bf04cbe9d93326c2e544e8a2b3e8467b4810df35ebb666d7f1", size = 56746, upload-time = "2026-03-18T23:52:15.466Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/2d/c6a8949aa9d5e6b69f7dcb9e792f8b2ff17d93204cc69cc520deff221b3b/fgmetric-0.2.0-py3-none-any.whl", hash = "sha256:44b903aa9a66f70380df8cb4c69eb63fa1829f9dc60c11327885d9245bf5e825", size = 15474, upload-time = "2026-03-18T23:52:14.077Z" },
 ]
 
 [[package]]

--- a/pixi.lock
+++ b/pixi.lock
@@ -186,6 +186,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/26/78/eb1e064ea8b9df3b87b167bfd7a407b2f615a4291e06cba756727adfa06c/duckdb-1.5.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/55/28/b363f21ca15ef86c8ee4c147b2831852c80b218e0616e0aec02f829eee26/fgpyo-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/0e/bfc3d7de5d1788871d1be3e6862fe3e56d92b446909b7b032c373fc4ecab/google_auth_oauthlib-0.8.0-py2.py3-none-any.whl
@@ -220,6 +221,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a1/a3/09d929a40e6727274b0b500ad06e1b3f35d4f4665ae1c8ba65acbb17e9b5/pydantic_core-2.46.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/df/a6/c100df6c8118b4ce1f9c086bb9cf5bccd4f71d05ceb2ecf474f3b0ea87b8/pysam-0.23.3-cp312-cp312-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/80/5a/3806f44eb47387e8af803508cdd6bbc0df784febf4dc010700be04a1ff89/pyspark-3.5.8.tar.gz
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/a6/145655273568ee78a581e734cf35beb9e33a370b29c5d3c8fee3744de29f/python_json_logger-2.0.7-py3-none-any.whl
@@ -234,6 +236,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/f2/6b7627dfe7b4e418e295e254bb15c3a6455f11f8c0ad0d43113f678049c3/sphinxcontrib_napoleon-0.7-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
@@ -243,6 +246,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a7/b4e6a19925c900be9f98bec0a75e6e8f79bb53bdeb891916609ab3958967/uvloop-0.21.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/66/3e/868e5c3364b6cee19ff3e1a122194fa4ce51def02c61023970442162859e/yarl-1.23.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/ed/5baf549131c47cbf5a00c35c7db7a78d5aa3c405605255a1496160a96a87/zlib_ng-1.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: ./divref
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -376,6 +380,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2d/8a/3e25b5d03bcf1fb99d189912f8ce92b1db4f9c8778e1b1f55745973a855a/duckdb-1.5.2-cp312-cp312-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/55/28/b363f21ca15ef86c8ee4c147b2831852c80b218e0616e0aec02f829eee26/fgpyo-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/80/4f6e318ee2a7c0750ed724fa33a4bdf1eacdc5a39a7a24e818a773cd91af/frozenlist-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/0e/bfc3d7de5d1788871d1be3e6862fe3e56d92b446909b7b032c373fc4ecab/google_auth_oauthlib-0.8.0-py2.py3-none-any.whl
@@ -410,6 +415,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/fb/caaa8ee23861c170f07dbd58fc2be3a2c02a32637693cbb23eef02e84808/pydantic_core-2.46.1-cp312-cp312-macosx_10_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a2/6b/dd9f94da44463ecfddb7075f1048c044155c725d7d79fde2e7957561a3b0/pysam-0.23.3-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/80/5a/3806f44eb47387e8af803508cdd6bbc0df784febf4dc010700be04a1ff89/pyspark-3.5.8.tar.gz
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/a6/145655273568ee78a581e734cf35beb9e33a370b29c5d3c8fee3744de29f/python_json_logger-2.0.7-py3-none-any.whl
@@ -424,6 +430,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/f2/6b7627dfe7b4e418e295e254bb15c3a6455f11f8c0ad0d43113f678049c3/sphinxcontrib_napoleon-0.7-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/5e/7625b76cd10f98f1516c36ce0346de62061156352353ef2da44e5c21523c/tornado-6.5.5-cp39-abi3-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
@@ -433,6 +440,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/43/3e/92c03f4d05e50f09251bd8b2b2b584a2a7f8fe600008bcc4523337abe676/uvloop-0.21.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/6f/c6554045d59d64052698add01226bc867b52fe4a12373415d7991fdca95d/yarl-1.23.0-cp312-cp312-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e4/6f/ad3b032d3881a5f35d673b429a8a524d8cb2b56d81f8ca4194117a502509/zlib_ng-1.0.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: ./divref
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -565,6 +573,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/bb/58001f0815002b1a93431bf907f77854085c7d049b83d521814a07b9db0b/duckdb-1.5.2-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/55/28/b363f21ca15ef86c8ee4c147b2831852c80b218e0616e0aec02f829eee26/fgpyo-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2b/94/5c8a2b50a496b11dd519f4a24cb5496cf125681dd99e94c604ccdea9419a/frozenlist-1.8.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/0e/bfc3d7de5d1788871d1be3e6862fe3e56d92b446909b7b032c373fc4ecab/google_auth_oauthlib-0.8.0-py2.py3-none-any.whl
@@ -599,6 +608,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fa/61/bcffaa52894489ff89e5e1cdde67429914bf083c0db7296bef153020f786/pydantic_core-2.46.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f3/e9/686e711a559a02e4c3ba0bc78cf031d9ddb525e9f0b2984d1b66536ba94a/pysam-0.23.3-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/80/5a/3806f44eb47387e8af803508cdd6bbc0df784febf4dc010700be04a1ff89/pyspark-3.5.8.tar.gz
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/a6/145655273568ee78a581e734cf35beb9e33a370b29c5d3c8fee3744de29f/python_json_logger-2.0.7-py3-none-any.whl
@@ -613,6 +623,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/f2/6b7627dfe7b4e418e295e254bb15c3a6455f11f8c0ad0d43113f678049c3/sphinxcontrib_napoleon-0.7-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/8c/77f5097695f4dd8255ecbd08b2a1ed8ba8b953d337804dd7080f199e12bf/tornado-6.5.5-cp39-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
@@ -622,6 +633,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8c/4c/03f93178830dc7ce8b4cdee1d36770d2f5ebb6f3d37d354e061eefc73545/uvloop-0.21.0-cp312-cp312-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/2a/725ecc166d53438bc88f76822ed4b1e3b10756e790bafd7b523fe97c322d/yarl-1.23.0-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/7c/67d4a0bb72039f8a8e11cd711aed63a0adf83961fea668e204b07d6f469d/zlib_ng-1.0.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: ./divref
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -1765,10 +1777,11 @@ packages:
 - pypi: ./divref
   name: divref
   version: 0.1.0
-  sha256: 0f38e966179a65bbeb9bf8356d6c3f6cab4e64bddbc31ae5feb5eb88b4b80e2e
+  sha256: 68c3e18c23433da70cd9f22fe5a0b64fc17bf22a35da6812ace25f15008591ce
   requires_dist:
   - defopt~=6.4
   - duckdb>=1.0
+  - fgpyo>=1.5.1
   - hail>=0.2
   - pandas>=2.0
   - polars>=1.0
@@ -1832,6 +1845,17 @@ packages:
   - pyarrow ; extra == 'all'
   - adbc-driver-manager ; extra == 'all'
   requires_python: '>=3.10.0'
+- pypi: https://files.pythonhosted.org/packages/55/28/b363f21ca15ef86c8ee4c147b2831852c80b218e0616e0aec02f829eee26/fgpyo-1.5.1-py3-none-any.whl
+  name: fgpyo
+  version: 1.5.1
+  sha256: 0de80c20929fe9e249841f419f31d7ae11bf3a3919e7bd0f576d1b88259eb12c
+  requires_dist:
+  - attrs>=19.3.0
+  - pysam>=0.22.1
+  - strenum>=0.4.15,<0.5
+  - typing-extensions>=4.12.2 ; python_full_version < '3.13'
+  - zlib-ng>=0.5.1
+  requires_python: '>=3.10.0,<4.0'
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
   md5: 0c96522c6bdaed4b1566d11387caaf45
@@ -4488,6 +4512,21 @@ packages:
   - pkg:pypi/pyparsing?source=hash-mapping
   size: 110893
   timestamp: 1769003998136
+- pypi: https://files.pythonhosted.org/packages/a2/6b/dd9f94da44463ecfddb7075f1048c044155c725d7d79fde2e7957561a3b0/pysam-0.23.3-cp312-cp312-macosx_10_13_x86_64.whl
+  name: pysam
+  version: 0.23.3
+  sha256: 69f90c0867fe43f04004bcea963f6b2e68b39180afab54bf551f61f43856638b
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/df/a6/c100df6c8118b4ce1f9c086bb9cf5bccd4f71d05ceb2ecf474f3b0ea87b8/pysam-0.23.3-cp312-cp312-manylinux_2_28_x86_64.whl
+  name: pysam
+  version: 0.23.3
+  sha256: 4099393fc5097b5081c7efaf46b0109e4f0a8ed18f86d497219a8bf739c73992
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/f3/e9/686e711a559a02e4c3ba0bc78cf031d9ddb525e9f0b2984d1b66536ba94a/pysam-0.23.3-cp312-cp312-macosx_11_0_arm64.whl
+  name: pysam
+  version: 0.23.3
+  sha256: 2310d72bfae7a0980d414156267e25b57aa221a768c11c087f3f7d00ceb9fed4
+  requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
   sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
   md5: 461219d1a5bd61342293efa2c0c90eac
@@ -5223,6 +5262,20 @@ packages:
   requires_dist:
   - six>=1.5.2
   - pockets>=0.3
+- pypi: https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl
+  name: strenum
+  version: 0.4.15
+  sha256: a30cda4af7cc6b5bf52c8055bc4bf4b2b6b14a93b574626da33df53cf7740659
+  requires_dist:
+  - sphinx ; extra == 'docs'
+  - sphinx-rtd-theme ; extra == 'docs'
+  - myst-parser[linkify] ; extra == 'docs'
+  - twine ; extra == 'release'
+  - pytest ; extra == 'test'
+  - pytest-black ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-pylint ; extra == 'test'
+  - pylint ; extra == 'test'
 - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
   sha256: 3f661e98a09f976775a494488beb3d35ebb00f535b169c6bd891f2e280d55783
   md5: 3b887b7b3468b0f494b4fad40178b043
@@ -5723,6 +5776,21 @@ packages:
   - pkg:pypi/yte?source=hash-mapping
   size: 16215
   timestamp: 1764250734338
+- pypi: https://files.pythonhosted.org/packages/6a/ed/5baf549131c47cbf5a00c35c7db7a78d5aa3c405605255a1496160a96a87/zlib_ng-1.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: zlib-ng
+  version: 1.0.0
+  sha256: 5332f9452b2fc27e47a1ca78fc150689ed9c51c7f449a5467bf41c4b206c439f
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/a1/7c/67d4a0bb72039f8a8e11cd711aed63a0adf83961fea668e204b07d6f469d/zlib_ng-1.0.0-cp312-cp312-macosx_11_0_arm64.whl
+  name: zlib-ng
+  version: 1.0.0
+  sha256: c01e44613d9a4cc1f6f6dcfab03ae43fd3b4f9bd909006398c75fe4a1fb48333
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/e4/6f/ad3b032d3881a5f35d673b429a8a524d8cb2b56d81f8ca4194117a502509/zlib_ng-1.0.0-cp312-cp312-macosx_10_13_x86_64.whl
+  name: zlib-ng
+  version: 1.0.0
+  sha256: d894ed89fd1f53344b8334333794f53d7119da034b49e08e39f0d2b05a1f699c
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
   sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
   md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829

--- a/pixi.lock
+++ b/pixi.lock
@@ -186,6 +186,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/26/78/eb1e064ea8b9df3b87b167bfd7a407b2f615a4291e06cba756727adfa06c/duckdb-1.5.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/2d/c6a8949aa9d5e6b69f7dcb9e792f8b2ff17d93204cc69cc520deff221b3b/fgmetric-0.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/55/28/b363f21ca15ef86c8ee4c147b2831852c80b218e0616e0aec02f829eee26/fgpyo-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl
@@ -380,6 +381,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2d/8a/3e25b5d03bcf1fb99d189912f8ce92b1db4f9c8778e1b1f55745973a855a/duckdb-1.5.2-cp312-cp312-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/2d/c6a8949aa9d5e6b69f7dcb9e792f8b2ff17d93204cc69cc520deff221b3b/fgmetric-0.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/55/28/b363f21ca15ef86c8ee4c147b2831852c80b218e0616e0aec02f829eee26/fgpyo-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/80/4f6e318ee2a7c0750ed724fa33a4bdf1eacdc5a39a7a24e818a773cd91af/frozenlist-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl
@@ -573,6 +575,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/bb/58001f0815002b1a93431bf907f77854085c7d049b83d521814a07b9db0b/duckdb-1.5.2-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/2d/c6a8949aa9d5e6b69f7dcb9e792f8b2ff17d93204cc69cc520deff221b3b/fgmetric-0.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/55/28/b363f21ca15ef86c8ee4c147b2831852c80b218e0616e0aec02f829eee26/fgpyo-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2b/94/5c8a2b50a496b11dd519f4a24cb5496cf125681dd99e94c604ccdea9419a/frozenlist-1.8.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl
@@ -1777,10 +1780,11 @@ packages:
 - pypi: ./divref
   name: divref
   version: 0.1.0
-  sha256: 68c3e18c23433da70cd9f22fe5a0b64fc17bf22a35da6812ace25f15008591ce
+  sha256: 5605ad3b0c9dc74efec75e166109802918ed5f8eba1a269dedb3a57681009fcc
   requires_dist:
   - defopt~=6.4
   - duckdb>=1.0
+  - fgmetric>=0.2.0
   - fgpyo>=1.5.1
   - hail>=0.2
   - pandas>=2.0
@@ -1845,6 +1849,15 @@ packages:
   - pyarrow ; extra == 'all'
   - adbc-driver-manager ; extra == 'all'
   requires_python: '>=3.10.0'
+- pypi: https://files.pythonhosted.org/packages/fb/2d/c6a8949aa9d5e6b69f7dcb9e792f8b2ff17d93204cc69cc520deff221b3b/fgmetric-0.2.0-py3-none-any.whl
+  name: fgmetric
+  version: 0.2.0
+  sha256: 44b903aa9a66f70380df8cb4c69eb63fa1829f9dc60c11327885d9245bf5e825
+  requires_dist:
+  - pydantic>=2.11.4
+  - fgpyo~=1.2.0 ; extra == 'benchmark'
+  - pytest-benchmark~=5.1.0 ; extra == 'benchmark'
+  requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/55/28/b363f21ca15ef86c8ee4c147b2831852c80b218e0616e0aec02f829eee26/fgpyo-1.5.1-py3-none-any.whl
   name: fgpyo
   version: 1.5.1


### PR DESCRIPTION
## Summary

Addresses issues #20, #22, and #25 — all closely related code-quality improvements touching the same files.

- **#20**: Added `HailExpression` type alias in `alias.py` to replace bare `Any` in Hail DSL expression parameters. Updated `haplotype.py` and `compute_haplotypes.py` to use `HailExpression`/`hl.Table` instead of `Any`.
- **#22**: Changed `temp_dir` parameter in `compute_haplotypes` from `HailPath` to `Path`; it is always a local filesystem path passed to `hl.init()`. Updated the corresponding test.
- **#25**: Added Google-style docstrings to all nested helper functions in `haplotype.py` (`get_chunk_until_next_variant`, `get_range`) and `compute_haplotypes.py` (`agg_haplos`, `collapse_haplos_across_samples`, `map_haplo_group`, `get_haplotype_summary`, `get_variant`, `get_gnomad_freq`). Expanded the `setup_logging` docstring with a missing `Args:` section.

## Test plan

- [x] `uv run --directory divref poe check-all` passes (mypy and pytest; format/lint failures are pre-existing in the untracked `extract_gnomad_single_afs.py` file)
- [x] `test_compute_haplotypes` still passes with `temp_dir` as `Path`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add reference-genome parameter for FASTA and variation ratio workflows.
  * Added upfront path validation to catch missing/unwritable files early.

* **Refactor**
  * Tools now accept standard pathlib.Path for filesystem arguments.
  * Removed obsolete credentials parameter from gnomAD sites VCF tool.

* **Documentation**
  * Expanded function docstrings and clarified test descriptions.

* **Chores**
  * Added runtime dependencies: fgmetric and fgpyo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->