### PR TITLE
feat: first stage of workflow to generate DivRef resource

### DIFF
--- a/workflows/config/config.yml
+++ b/workflows/config/config.yml
@@ -1,2 +1,1 @@
-experiment: "experiment1"
-samples: ["sample1", "sample2"]
+chromosomes: ["chr22"]

--- a/workflows/config/config_schema.yml
+++ b/workflows/config/config_schema.yml
@@ -9,6 +9,11 @@ properties:
     description: List of chromosomes to generate the resource for.
     default: ["chr1", "chr2", "chr3", "chr4", "chr5", "chr6", "chr7", "chr8", "chr9", "chr10", "chr11", "chr12", "chr13", "chr14", "chr15", "chr16", "chr17", "chr18", "chr19", "chr20", "chr21", "chr22", "chrX", "chrY"]
 
+  populations:
+    type: array
+    description: List of populations to use.
+    default: ["afr", "amr", "eas", "sas", "nfe"]
+
   hgdp_1kg_phased_bcf_prefix:
     type: string
     description: Prefix of the GCS URI for the HGDP+1KG phased BCF files.
@@ -18,6 +23,21 @@ properties:
     type: string
     description: Suffix of the GCS URI for the HGDP+1KG phased BCF files.
     default: ".filtered.SNV_INDEL.phased.shapeit5.bcf"
+
+  hgdp_1kg_variant_annotation_hail_table:
+    type: string
+    description: GCS URI to the HGDP+1KG gnomAD variant annotations Hail table.
+    default: "gs://gcp-public-data--gnomad/release/3.1.2/ht/genomes/gnomad.genomes.v3.1.2.hgdp_1kg_subset_variant_annotations.ht"
+
+  hgdp_1kg_sample_metadata_hail_table:
+    type: string
+    description: GCS URI to the HGDP+1KG gnomAD sample metadata Hail table.
+    default: "gs://gcp-public-data--gnomad/release/3.1.2/ht/genomes/gnomad.genomes.v3.1.2.hgdp_1kg_subset_sample_meta.ht"
+
+  hgdp_1kg_min_pop_af_extract_gnomad_afs:
+    type: number
+    description: Minimum allele frequency for at least one selected population when running `divref extract-gnomad-afs`.
+    default: 0.001
 
   work_dir:
     type: string

--- a/workflows/config/config_schema.yml
+++ b/workflows/config/config_schema.yml
@@ -1,24 +1,25 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-description: Config schema for divref-wf
+description: Configuration schema for generate_divref.smk
 
 type: object
 
 properties:
-  experiment:
-    type: string
-    description: Name of the experiment.
-    example: "divref-wf"
-
-  samples:
+  chromosomes:
     type: array
-    description: List of samples.
-    example: ["sample1", "sample2"]
+    description: List of chromosomes to generate the resource for.
+    default: ["chr1", "chr2", "chr3", "chr4", "chr5", "chr6", "chr7", "chr8", "chr9", "chr10", "chr11", "chr12", "chr13", "chr14", "chr15", "chr16", "chr17", "chr18", "chr19", "chr20", "chr21", "chr22", "chrX", "chrY"]
 
-  p_value_cutoff:
-    type: number
-    description: P-value cutoff for statistical significance.
-    default: 0.05
+  hgdp_1kg_phased_bcf_prefix:
+    type: string
+    description: Prefix of the GCS URI for the HGDP+1KG phased BCF files.
+    default: "gs://gcp-public-data--gnomad/resources/hgdp_1kg/phased_haplotypes_v2/hgdp1kgp_"
 
-required:
-  - experiment
-  - samples
+  hgdp_1kg_phased_bcf_suffix:
+    type: string
+    description: Suffix of the GCS URI for the HGDP+1KG phased BCF files.
+    default: ".filtered.SNV_INDEL.phased.shapeit5.bcf"
+
+  work_dir:
+    type: string
+    description: Path to the working directory for intermediate files.
+    default: data/work

--- a/workflows/config/config_schema.yml
+++ b/workflows/config/config_schema.yml
@@ -6,11 +6,15 @@ type: object
 properties:
   chromosomes:
     type: array
+    items:
+      type: string
     description: List of chromosomes to generate the resource for.
     default: ["chr1", "chr2", "chr3", "chr4", "chr5", "chr6", "chr7", "chr8", "chr9", "chr10", "chr11", "chr12", "chr13", "chr14", "chr15", "chr16", "chr17", "chr18", "chr19", "chr20", "chr21", "chr22", "chrX", "chrY"]
 
   populations:
     type: array
+    items:
+      type: string
     description: List of populations to use.
     default: ["afr", "amr", "eas", "sas", "nfe"]
 

--- a/workflows/config/config_schema.yml
+++ b/workflows/config/config_schema.yml
@@ -8,6 +8,8 @@ properties:
     type: array
     items:
       type: string
+    minItems: 1
+    uniqueItems: true
     description: List of chromosomes to generate the resource for.
     default: ["chr1", "chr2", "chr3", "chr4", "chr5", "chr6", "chr7", "chr8", "chr9", "chr10", "chr11", "chr12", "chr13", "chr14", "chr15", "chr16", "chr17", "chr18", "chr19", "chr20", "chr21", "chr22", "chrX", "chrY"]
 
@@ -15,6 +17,8 @@ properties:
     type: array
     items:
       type: string
+    minItems: 1
+    uniqueItems: true
     description: List of populations to use.
     default: ["afr", "amr", "eas", "sas", "nfe"]
 
@@ -40,6 +44,8 @@ properties:
 
   hgdp_1kg_min_pop_af_extract_gnomad_afs:
     type: number
+    minimum: 0
+    maximum: 1
     description: Minimum allele frequency for at least one selected population when running `divref extract-gnomad-afs`.
     default: 0.001
 

--- a/workflows/generate_divref.smk
+++ b/workflows/generate_divref.smk
@@ -4,6 +4,7 @@
 # Final output is a set of per-chromosome FASTA files and a DuckDB index.
 ####################################################################################################
 
+import os
 from pathlib import Path
 from snakemake.utils import validate
 
@@ -87,6 +88,7 @@ rule extract_gnomad_afs:
     params:
         variant_ht=HGDP_1KG_VARIANT_ANNOTATION_HAIL_TABLE,
         freq_threshold=HGDP_1KG_MIN_POP_AF_EXTRACT_GNOMAD_AFS,
+        populations=" ".join(POPS),
     shell:
         """
         (
@@ -94,7 +96,8 @@ rule extract_gnomad_afs:
                 --in-gnomad-sites-table {params.variant_ht} \
                 --out-variant-annotation-table {output.variant_ht} \
                 --contig {wildcards.chrom} \
-                --freq-threshold {params.freq_threshold}
+                --freq-threshold {params.freq_threshold} \
+                --populations {params.populations}
         ) &> {log}
         """
 

--- a/workflows/generate_divref.smk
+++ b/workflows/generate_divref.smk
@@ -38,7 +38,7 @@ VCF_EXTS: list[str] = [".vcf.gz", ".vcf.gz.tbi"]
 
 rule all:
     input:
-        f"{WORK_DIR}/hgdp_1kg.sample_metadata.ht",
+        f"{WORK_DIR}/inputs/hgdp_1kg.sample_metadata.ht",
         expand(f"{WORK_DIR}/inputs/hgdp_1kg.sites.{{chrom}}.ht", chrom=CHROMS),
         expand(
             f"{WORK_DIR}/inputs/hgdp_1kg.phased_genotypes.{{chrom}}{{ext}}",
@@ -104,7 +104,7 @@ rule extract_gnomad_afs:
 ####################################################################################################
 rule extract_sample_metadata:
     output:
-        sample_ht=directory(f"{WORK_DIR}/hgdp_1kg.sample_metadata.ht"),
+        sample_ht=directory(f"{WORK_DIR}/inputs/hgdp_1kg.sample_metadata.ht"),
     log:
         "logs/generate_divref/extract_sample_metadata.log",
     params:

--- a/workflows/generate_divref.smk
+++ b/workflows/generate_divref.smk
@@ -19,11 +19,15 @@ validate(config, os.path.join(workflow.basedir, "config", "config_schema.yml"))
 
 WORK_DIR: Path = Path(config["work_dir"])
 CHROMS: list[str] = config["chromosomes"]
+POPS: list[str] = config["populations"]
 
 # The HGDP+1KG phased BCF files are at
 # "{HGDP_1KG_PHASED_BCF_PREFIX}.{chrom}.{HGDP_1KG_PHASED_BCF_SUFFIX}"
 HGDP_1KG_PHASED_BCF_PREFIX: str = config["hgdp_1kg_phased_bcf_prefix"]
 HGDP_1KG_PHASED_BCF_SUFFIX: str = config["hgdp_1kg_phased_bcf_suffix"]
+HGDP_1KG_VARIANT_ANNOTATION_HAIL_TABLE: str = config["hgdp_1kg_variant_annotation_hail_table"]
+HGDP_1KG_SAMPLE_METADATA_HAIL_TABLE: str = config["hgdp_1kg_sample_metadata_hail_table"]
+HGDP_1KG_MIN_POP_AF_EXTRACT_GNOMAD_AFS: float = config["hgdp_1kg_min_pop_af_extract_gnomad_afs"]
 
 VCF_EXTS: list[str] = [".vcf.gz", ".vcf.gz.tbi"]
 
@@ -34,8 +38,8 @@ VCF_EXTS: list[str] = [".vcf.gz", ".vcf.gz.tbi"]
 
 rule all:
     input:
-        #        f"{WORK_DIR}/inputs/hgdp_1kg_sample_metadata.ht",
-        #expand(f"{WORK_DIR}/inputs/hgdp_1kg.sites.{{chrom}}.ht", chrom=CHROMS),
+        f"{WORK_DIR}/hgdp_1kg.sample_metadata.ht",
+        expand(f"{WORK_DIR}/inputs/hgdp_1kg.sites.{{chrom}}.ht", chrom=CHROMS),
         expand(
             f"{WORK_DIR}/inputs/hgdp_1kg.phased_genotypes.{{chrom}}{{ext}}",
             chrom=CHROMS,
@@ -67,5 +71,49 @@ rule subset_phased_genotypes:
                 --output {output.vcf} \
                 --write-index=tbi \
                 {params.bcf}
+        ) &> {log}
+        """
+
+
+####################################################################################################
+# Extracts allele frequencies from the HGDP+1KG gnomAD subset for the given populations and subsets
+# to sites over the specified minimum allele frequency in at least one population.
+####################################################################################################
+rule extract_gnomad_afs:
+    output:
+        variant_ht=directory(f"{WORK_DIR}/inputs/hgdp_1kg.sites.{{chrom}}.ht"),
+    log:
+        "logs/generate_divref/extract_gnomad_afs.{chrom}.log",
+    params:
+        variant_ht=HGDP_1KG_VARIANT_ANNOTATION_HAIL_TABLE,
+        freq_threshold=HGDP_1KG_MIN_POP_AF_EXTRACT_GNOMAD_AFS,
+    shell:
+        """
+        (
+            divref extract-gnomad-afs \
+                --in-gnomad-sites-table {params.variant_ht} \
+                --out-variant-annotation-table {output.variant_ht} \
+                --contig {wildcards.chrom} \
+                --freq-threshold {params.freq_threshold}
+        ) &> {log}
+        """
+
+
+####################################################################################################
+# Extracts selected fields from sample metadata.
+####################################################################################################
+rule extract_sample_metadata:
+    output:
+        sample_ht=directory(f"{WORK_DIR}/hgdp_1kg.sample_metadata.ht"),
+    log:
+        "logs/generate_divref/extract_sample_metadata.log",
+    params:
+        sample_ht=HGDP_1KG_SAMPLE_METADATA_HAIL_TABLE,
+    shell:
+        """
+        (
+            divref extract-sample-metadata \
+                --in-gnomad-hgdp-sample-data {params.sample_ht} \
+                --out-sample-metadata {output.sample_ht}
         ) &> {log}
         """

--- a/workflows/generate_divref.smk
+++ b/workflows/generate_divref.smk
@@ -1,0 +1,71 @@
+####################################################################################################
+# Generates a DivRef-format resource of human haplotypes.
+#
+# Final output is a set of per-chromosome FASTA files and a DuckDB index.
+####################################################################################################
+
+from pathlib import Path
+from snakemake.utils import validate
+
+####################################################################################################
+# Inputs
+####################################################################################################
+
+
+configfile: os.path.join(workflow.basedir, "config", "config.yml")
+
+
+validate(config, os.path.join(workflow.basedir, "config", "config_schema.yml"))
+
+WORK_DIR: Path = Path(config["work_dir"])
+CHROMS: list[str] = config["chromosomes"]
+
+# The HGDP+1KG phased BCF files are at
+# "{HGDP_1KG_PHASED_BCF_PREFIX}.{chrom}.{HGDP_1KG_PHASED_BCF_SUFFIX}"
+HGDP_1KG_PHASED_BCF_PREFIX: str = config["hgdp_1kg_phased_bcf_prefix"]
+HGDP_1KG_PHASED_BCF_SUFFIX: str = config["hgdp_1kg_phased_bcf_suffix"]
+
+VCF_EXTS: list[str] = [".vcf.gz", ".vcf.gz.tbi"]
+
+####################################################################################################
+# Rules
+####################################################################################################
+
+
+rule all:
+    input:
+        #        f"{WORK_DIR}/inputs/hgdp_1kg_sample_metadata.ht",
+        #expand(f"{WORK_DIR}/inputs/hgdp_1kg.sites.{{chrom}}.ht", chrom=CHROMS),
+        expand(
+            f"{WORK_DIR}/inputs/hgdp_1kg.phased_genotypes.{{chrom}}{{ext}}",
+            chrom=CHROMS,
+            ext=VCF_EXTS,
+        ),
+
+
+####################################################################################################
+# Extracts the phased genotypes for all HGDP+1KG samples in the specified locus.
+#
+# Removes the INFO field, since this is not required for haplotype computation (allele frequencies
+# are re-annotated from the sites table), and it inflates the size on disk and subsequently the time
+# for Hail to load and parse the VCF with the `divref compute-haplotypes` tool.
+####################################################################################################
+rule subset_phased_genotypes:
+    output:
+        vcf=f"{WORK_DIR}/inputs/hgdp_1kg.phased_genotypes.{{chrom}}.vcf.gz",
+        tbi=f"{WORK_DIR}/inputs/hgdp_1kg.phased_genotypes.{{chrom}}.vcf.gz.tbi",
+    log:
+        "logs/generate_divref/subset_phased_genotypes.{chrom}.log",
+    params:
+        bcf=f"{HGDP_1KG_PHASED_BCF_PREFIX}{{chrom}}{HGDP_1KG_PHASED_BCF_SUFFIX}",
+    shell:
+        """
+        (
+            bcftools annotate \
+                --remove INFO \
+                --output-type z \
+                --output {output.vcf} \
+                --write-index=tbi \
+                {params.bcf}
+        ) &> {log}
+        """


### PR DESCRIPTION
## Summary

- Adds `generate_divref.smk`, a new Snakemake workflow that orchestrates the first stage of the DivRef pipeline: extracting per-chromosome inputs from the HGDP+1KG gnomAD data on GCS
- Replaces the placeholder config schema with a real schema covering all workflow parameters, with documented defaults
- Updates `config.yml` to a minimal working example (`chr22` only) for development and testing

## What the workflow does (so far)

Three rules are wired up, producing outputs under `work_dir/inputs/`:

| Rule | Tool / command | Output |
|---|---|---|
| `subset_phased_genotypes` | `bcftools annotate` | Per-chromosome VCF.gz + TBI, INFO field stripped to reduce size |
| `extract_gnomad_afs` | `divref extract-gnomad-afs` | Per-chromosome Hail table of per-population AFs, filtered by minimum AF |
| `extract_sample_metadata` | `divref extract-sample-metadata` | Sample metadata Hail table |

The `rule all` target collects these three output types across all configured chromosomes.

## Config parameters added

- `chromosomes` — list of contigs to process (default: all canonical autosomes + chrX/Y)
- `populations` — gnomAD population codes (default: afr, amr, eas, sas, nfe)
- `hgdp_1kg_phased_bcf_prefix` / `_suffix` — GCS URI fragments for the phased BCF files
- `hgdp_1kg_variant_annotation_hail_table` — GCS URI for gnomAD v3.1.2 HGDP+1KG variant annotations
- `hgdp_1kg_sample_metadata_hail_table` — GCS URI for gnomAD v3.1.2 HGDP+1KG sample metadata
- `hgdp_1kg_min_pop_af_extract_gnomad_afs` — minimum per-population AF filter (default: 0.001)
- `work_dir` — root for all intermediate outputs (default: `data/work`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a workflow to generate DivRef-format human haplotype resources: per-chromosome phased genotypes, per-chromosome variant/site tables, and a consolidated sample-metadata table.

* **Configuration Updates**
  * Removed top-level experiment/samples; added selectable chromosomes and populations (with defaults), new HGDP+1KG input parameters, a min allele-frequency threshold, work directory default, and relaxed schema required enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->