### PR TITLE
feat: add rule to compute haplotypes

### DIFF
--- a/divref/divref/tools/extract_gnomad_afs.py
+++ b/divref/divref/tools/extract_gnomad_afs.py
@@ -60,5 +60,5 @@ def extract_gnomad_afs(
 
     va = va.select_globals(pops=populations)
     va = va.select(pop_freqs=hl.literal(pop_indices).map(lambda i: va.gnomad_freq[i]))
-    va = va.filter(hl.any(lambda x: x.AF > freq_threshold, va.pop_freqs))
+    va = va.filter(hl.any(lambda x: x.AF >= freq_threshold, va.pop_freqs))
     va.naive_coalesce(64).write(str(out_variant_annotation_table), overwrite=True)

--- a/divref/tests/tools/test_extract_gnomad_afs.py
+++ b/divref/tests/tools/test_extract_gnomad_afs.py
@@ -43,4 +43,4 @@ def test_extract_gnomad_afs(
 
     # All retained variants must exceed freq_threshold in at least one population
     min_max_af = va.aggregate(hl.agg.min(hl.max(va.pop_freqs.map(lambda x: x.AF))))
-    assert min_max_af > 0.001
+    assert min_max_af >= 0.001

--- a/workflows/config/config_schema.yml
+++ b/workflows/config/config_schema.yml
@@ -51,13 +51,14 @@ properties:
       Minimum allele frequency for at least one selected population when running `divref extract-gnomad-afs`.
       Must be <= `hgdp_1kg_min_pop_af_compute_haplotypes`. There are two AF thresholds set in this workflow.
       This one is to filter the GCS-hosted Hail table of sites down to a smaller size which is written to
-      disk for downstream tasks. This step is time-intensive and if we set a relaxed threshold it can be run\
+      disk for downstream tasks. This step is time-intensive and if we set a relaxed threshold it can be run
       once and the outputs re-used for cheaper re-filtering at more stringent thresholds at the `divref
       compute-haplotypes` step.
     default: 0.001
 
   hgdp_1kg_haplotype_window_size:
     type: integer
+    minimum: 1
     description: Window size in bp for grouping variants into haplotypes.
     default: 100
 

--- a/workflows/config/config_schema.yml
+++ b/workflows/config/config_schema.yml
@@ -2,6 +2,7 @@ $schema: "https://json-schema.org/draft/2020-12/schema"
 description: Configuration schema for generate_divref.smk
 
 type: object
+additionalProperties: false
 
 properties:
   chromosomes:

--- a/workflows/config/config_schema.yml
+++ b/workflows/config/config_schema.yml
@@ -46,8 +46,26 @@ properties:
     type: number
     minimum: 0
     maximum: 1
-    description: Minimum allele frequency for at least one selected population when running `divref extract-gnomad-afs`.
+    description: |
+      Minimum allele frequency for at least one selected population when running `divref extract-gnomad-afs`.
+      Must be <= `hgdp_1kg_min_pop_af_compute_haplotypes`. There are two AF thresholds set in this workflow.
+      This one is to filter the GCS-hosted Hail table of sites down to a smaller size which is written to
+      disk for downstream tasks. This step is time-intensive and if we set a relaxed threshold it can be run\
+      once and the outputs re-used for cheaper re-filtering at more stringent thresholds at the `divref
+      compute-haplotypes` step.
     default: 0.001
+
+  hgdp_1kg_haplotype_window_size:
+    type: integer
+    description: Window size in bp for grouping variants into haplotypes.
+    default: 100
+
+  hgdp_1kg_min_pop_af_compute_haplotypes:
+    type: number
+    minimum: 0
+    maximum: 1
+    description: Minimum allele frequency for at least one selected population when running `divref compute-haplotypes`.
+    default: 0.005
 
   work_dir:
     type: string

--- a/workflows/generate_divref.smk
+++ b/workflows/generate_divref.smk
@@ -29,6 +29,15 @@ HGDP_1KG_PHASED_BCF_SUFFIX: str = config["hgdp_1kg_phased_bcf_suffix"]
 HGDP_1KG_VARIANT_ANNOTATION_HAIL_TABLE: str = config["hgdp_1kg_variant_annotation_hail_table"]
 HGDP_1KG_SAMPLE_METADATA_HAIL_TABLE: str = config["hgdp_1kg_sample_metadata_hail_table"]
 HGDP_1KG_MIN_POP_AF_EXTRACT_GNOMAD_AFS: float = config["hgdp_1kg_min_pop_af_extract_gnomad_afs"]
+HGDP_1KG_HAPLOTYPE_WINDOW_SIZE: int = config["hgdp_1kg_haplotype_window_size"]
+HGDP_1KG_MIN_POP_AF_COMPUTE_HAPLOTYPES: float = config["hgdp_1kg_min_pop_af_compute_haplotypes"]
+
+if HGDP_1KG_MIN_POP_AF_EXTRACT_GNOMAD_AFS > HGDP_1KG_MIN_POP_AF_COMPUTE_HAPLOTYPES:
+    raise ValueError(
+        f"hgdp_1kg_min_pop_af_extract_gnomad_afs ({HGDP_1KG_MIN_POP_AF_EXTRACT_GNOMAD_AFS}) "
+        f"must be <= hgdp_1kg_min_pop_af_compute_haplotypes "
+        f"({HGDP_1KG_MIN_POP_AF_COMPUTE_HAPLOTYPES})"
+    )
 
 VCF_EXTS: list[str] = [".vcf.gz", ".vcf.gz.tbi"]
 
@@ -46,6 +55,7 @@ rule all:
             chrom=CHROMS,
             ext=VCF_EXTS,
         ),
+        expand(f"{WORK_DIR}/haplotypes/hgdp_1kg.haplotypes.{{chrom}}.ht", chrom=CHROMS),
 
 
 ####################################################################################################
@@ -103,7 +113,7 @@ rule extract_gnomad_afs:
 
 
 ####################################################################################################
-# Extracts selected fields from sample metadata.
+# Extracts selected fields from HGDP+1KG sample metadata.
 ####################################################################################################
 rule extract_sample_metadata:
     output:
@@ -118,5 +128,39 @@ rule extract_sample_metadata:
             divref extract-sample-metadata \
                 --in-gnomad-hgdp-sample-data {params.sample_ht} \
                 --out-sample-metadata {output.sample_ht}
+        ) &> {log}
+        """
+
+
+####################################################################################################
+# Compute haplotypes from the HGDP+1KG filtered sites, sample metadata, and phased genotypes.
+####################################################################################################
+rule compute_haplotypes:
+    input:
+        vcf=f"{WORK_DIR}/inputs/hgdp_1kg.phased_genotypes.{{chrom}}.vcf.gz",
+        tbi=f"{WORK_DIR}/inputs/hgdp_1kg.phased_genotypes.{{chrom}}.vcf.gz.tbi",
+        variant_ht=f"{WORK_DIR}/inputs/hgdp_1kg.sites.{{chrom}}.ht",
+        sample_ht=f"{WORK_DIR}/inputs/hgdp_1kg.sample_metadata.ht",
+    output:
+        haplotypes_ht=directory(f"{WORK_DIR}/haplotypes/hgdp_1kg.haplotypes.{{chrom}}.ht"),
+    log:
+        "logs/generate_divref/compute_haplotypes.{chrom}.log",
+    params:
+        window_size=HGDP_1KG_HAPLOTYPE_WINDOW_SIZE,
+        freq_threshold=HGDP_1KG_MIN_POP_AF_COMPUTE_HAPLOTYPES,
+        output_base=f"{WORK_DIR}/haplotypes/hgdp_1kg.haplotypes.{{chrom}}",
+    shell:
+        """
+        (
+            divref compute-haplotypes \
+                --vcfs-path {input.vcf} \
+                --gnomad-va-file {input.variant_ht} \
+                --gnomad-sa-file {input.sample_ht} \
+                --window-size {params.window_size} \
+                --freq-threshold {params.freq_threshold} \
+                --output-base {params.output_base}
+            
+            # remove intermediate files
+            rm -r {params.output_base}.[12].ht
         ) &> {log}
         """


### PR DESCRIPTION
## Summary

- Adds the `compute_haplotypes` Snakemake rule, wiring it into the pipeline after the existing
  input-extraction rules
- Adds `hgdp_1kg_haplotype_window_size` and `hgdp_1kg_min_pop_af_compute_haplotypes` config
  parameters with schema validation
- Adds a startup guard that raises an error if the extract AF threshold is stricter than the
  compute AF threshold, preventing silent incorrect results
- Fixes `extract_gnomad_afs` to use `>=` instead of `>`, matching the operator used in
  `compute_haplotypes`

## Details

**`compute_haplotypes` rule** joins the per-chromosome phased VCF, variant annotation table, and
sample metadata table produced by earlier rules, runs `divref compute-haplotypes`, and cleans up
intermediate checkpoint tables (`.1.ht`, `.2.ht`) on completion.

**Two-threshold design** — `hgdp_1kg_min_pop_af_extract_gnomad_afs` (default 0.001) is kept
deliberately lower than `hgdp_1kg_min_pop_af_compute_haplotypes` (default 0.005). The extract
tables are expensive Hail jobs against GCS data and serve as reusable checkpoints; setting a
relaxed threshold at extraction time means `compute_haplotypes` can be re-run at different
thresholds without re-extracting. `compute_haplotypes` re-filters the annotation table internally
before use. The startup guard enforces that the extract threshold is always ≤ the compute
threshold, turning the previously silent misconfiguration into a hard error.

**`>` → `>=` fix** in `extract_gnomad_afs` aligns the operator with `compute_haplotypes`
(line 262), so the two tools apply the threshold consistently when both are set to the same value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added haplotype computation step producing per‑chromosome haplotype outputs and new haplotype configuration parameters.
  * Added runtime validation to ensure allele‑frequency thresholds are consistent.

* **Bug Fixes**
  * Variant filtering adjusted to include variants that exactly meet the allele‑frequency threshold.

* **Chores**
  * Configuration schema tightened to reject unknown keys.

* **Tests**
  * Relaxed a test to accept the inclusive allele‑frequency boundary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->