### PR TITLE
feat: move filtering of haplotypes from create_fasta_and_index to compute_haplotypes

### DIFF
--- a/divref/divref/tools/compute_haplotypes.py
+++ b/divref/divref/tools/compute_haplotypes.py
@@ -42,8 +42,6 @@ def _get_haplotypes(
     Returns:
         Hail table of haplotypes with empirical frequency summaries.
     """
-    new_locus = windower_f(ht.locus)
-    ht = ht.annotate(new_locus=new_locus)
 
     def agg_haplos(arr: hl.Expression) -> hl.Expression:
         """
@@ -76,17 +74,6 @@ def _get_haplotypes(
                 .map_values(lambda arr: hl.len(arr))
             )
         )
-
-    ht_grouped = ht.group_by("new_locus").aggregate(
-        row_map=hl.dict(
-            hl.agg.collect((
-                ht.row_idx,
-                ht.row.select("locus", "alleles", "freq", "frequencies_by_pop"),
-            ))
-        ),
-        left_haplos=agg_haplos(ht.pops_and_ids_left),
-        right_haplos=agg_haplos(ht.pops_and_ids_right),
-    )
 
     def collapse_haplos_across_samples(
         pop: hl.Expression, arr1: hl.Expression, arr2: hl.Expression
@@ -137,14 +124,6 @@ def _get_haplotypes(
 
         return hl.array(hl.group_by(lambda x: x[0], flat)).map(map_haplo_group)
 
-    ht_grouped = ht_grouped.annotate(
-        all_haplos=hl.literal(list(pop_ints.values())).flatmap(
-            lambda pop: collapse_haplos_across_samples(
-                pop, ht_grouped.left_haplos, ht_grouped.right_haplos
-            )
-        )
-    )
-
     def get_haplotype_summary(a: hl.Expression) -> dict[str, hl.Expression]:
         """
         Extract the top-population frequency fields from a collapsed haplotype array.
@@ -169,6 +148,28 @@ def _get_haplotypes(
             min_variant_frequency=a_sorted[0].min_variant_frequency,
             all_pop_freqs=a_sorted.map(lambda x: x.drop("haplotype")),
         )
+
+    new_locus = windower_f(ht.locus)
+    ht = ht.annotate(new_locus=new_locus)
+
+    ht_grouped = ht.group_by("new_locus").aggregate(
+        row_map=hl.dict(
+            hl.agg.collect((
+                ht.row_idx,
+                ht.row.select("locus", "alleles", "freq", "frequencies_by_pop"),
+            ))
+        ),
+        left_haplos=agg_haplos(ht.pops_and_ids_left),
+        right_haplos=agg_haplos(ht.pops_and_ids_right),
+    )
+
+    ht_grouped = ht_grouped.annotate(
+        all_haplos=hl.literal(list(pop_ints.values())).flatmap(
+            lambda pop: collapse_haplos_across_samples(
+                pop, ht_grouped.left_haplos, ht_grouped.right_haplos
+            )
+        )
+    )
 
     ht_grouped = ht_grouped.transmute(
         all_haplos=hl.array(hl.group_by(lambda x: x.haplotype, ht_grouped.all_haplos)).map(
@@ -320,6 +321,9 @@ def compute_haplotypes(
         "row_idx",
         "frequencies_by_pop",
     )
+
+    if ht.count() == 0:
+        raise ValueError(f"No variants found with minimum population AF {variant_freq_threshold}.")
 
     window1 = _get_haplotypes(
         ht=ht,

--- a/divref/divref/tools/compute_haplotypes.py
+++ b/divref/divref/tools/compute_haplotypes.py
@@ -269,13 +269,14 @@ def compute_haplotypes(
         variant_freq_threshold: Minimum gnomAD population allele frequency to retain a variant.
         haplotype_freq_threshold: Minimum estimated gnomAD allele frequency for the haplotype to
             be retained.
-        output_base: Base output path; writes {output_base}.1.ht, {output_base}.2.ht,
-            and the final {output_base}.ht.
+        output_base: Base output path; writes {output_base}.variants.ht, {output_base}.1.ht,
+            {output_base}.2.ht, and the final {output_base}.ht.
         temp_dir: Local directory for Hail temporary files.
     """
     assert_path_is_readable(vcfs_path)
     assert_directory_exists(gnomad_va_file)
     assert_directory_exists(gnomad_sa_file)
+    assert_path_is_writable(output_base.with_suffix(output_base.suffix + ".variants.ht"))
     assert_path_is_writable(output_base.with_suffix(output_base.suffix + ".1.ht"))
     assert_path_is_writable(output_base.with_suffix(output_base.suffix + ".2.ht"))
     assert_path_is_writable(output_base.with_suffix(output_base.suffix + ".ht"))
@@ -321,8 +322,9 @@ def compute_haplotypes(
         "row_idx",
         "frequencies_by_pop",
     )
+    ht = ht.checkpoint(f"{str(output_base)}.variants.ht", overwrite=True)
 
-    if ht.count() == 0:
+    if ht.head(1).count() == 0:
         raise ValueError(f"No variants found with minimum population AF {variant_freq_threshold}.")
 
     window1 = _get_haplotypes(

--- a/divref/divref/tools/compute_haplotypes.py
+++ b/divref/divref/tools/compute_haplotypes.py
@@ -20,6 +20,7 @@ def _get_haplotypes(
     idx: int,
     output_base: Path,
     pop_ints: dict[str, int],
+    haplotype_freq_threshold: float,
 ) -> hl.Table:
     """
     Group variants into haplotypes within genomic windows and compute empirical frequencies.
@@ -35,6 +36,7 @@ def _get_haplotypes(
         idx: Index of this windowing pass (1 or 2), used in the checkpoint filename.
         output_base: Base path for output; checkpoint written to {output_base}.{idx}.ht.
         pop_ints: Mapping from population code to integer index.
+        haplotype_freq_threshold: Minimum haplotype frequency to retain.
 
     Returns:
         Hail table of haplotypes with empirical frequency summaries.
@@ -215,6 +217,33 @@ def _get_haplotypes(
         )[0]
     )
 
+    # Filter out any haplotypes with minimum variant frequency <= 0
+    count_orig: int = hte.count()
+    logger.info(f"{count_orig} haplotypes identified")
+
+    hte = hte.filter(hte.min_variant_frequency > 0)
+    count_with_nonzero_freq: int = hte.count()
+    if count_with_nonzero_freq < count_orig:
+        logger.warning(
+            f"Removed {count_orig - count_with_nonzero_freq} haplotypes with "
+            "min_variant_frequency <= 0",
+        )
+
+    # Estimate the fraction of phased
+    fraction_phased: float = hte.max_empirical_AF / hte.min_variant_frequency
+    hte = hte.annotate(
+        fraction_phased=fraction_phased,
+        estimated_gnomad_AF=hl.min(
+            hte.gnomad_freqs.map(lambda x: x[hte.max_pop].AF * fraction_phased)
+        ),
+    )
+    hte = hte.filter(hte.estimated_gnomad_AF >= haplotype_freq_threshold)
+    count_after_freq_filter: int = hte.count()
+    logger.info(
+        f"{count_after_freq_filter} haplotypes remaining with "
+        f"estimated_gnomad_AF >= {haplotype_freq_threshold}"
+    )
+
     logger.info("Writing %s.%s.ht ...", output_base, idx)
     return hte.checkpoint(f"{str(output_base)}.{idx}.ht", overwrite=True)
 
@@ -225,7 +254,8 @@ def compute_haplotypes(
     gnomad_va_file: Path,
     gnomad_sa_file: Path,
     window_size: int,
-    freq_threshold: float,
+    variant_freq_threshold: float,
+    haplotype_freq_threshold: float,
     output_base: Path,
     temp_dir: Path = Path("/tmp"),
 ) -> None:
@@ -243,7 +273,9 @@ def compute_haplotypes(
         gnomad_sa_file: Path to the gnomAD sample metadata Hail table
             (from extract_sample_metadata).
         window_size: Base window size in bp for grouping variants into haplotypes.
-        freq_threshold: Minimum gnomAD population allele frequency to retain a variant.
+        variant_freq_threshold: Minimum gnomAD population allele frequency to retain a variant.
+        haplotype_freq_threshold: Minimum estimated gnomAD allele frequency for the haplotype to
+            be retained.
         output_base: Base output path; writes {output_base}.1.ht, {output_base}.2.ht,
             and the final {output_base}.ht.
         temp_dir: Local directory for Hail temporary files.
@@ -259,7 +291,9 @@ def compute_haplotypes(
 
     gnomad_sa = hl.read_table(str(gnomad_sa_file))
     gnomad_va = hl.read_table(str(gnomad_va_file))
-    gnomad_va = gnomad_va.filter(hl.max(gnomad_va.pop_freqs.map(lambda x: x.AF)) >= freq_threshold)
+    gnomad_va = gnomad_va.filter(
+        hl.max(gnomad_va.pop_freqs.map(lambda x: x.AF)) >= variant_freq_threshold
+    )
 
     mt = hl.import_vcf(
         str(vcfs_path),
@@ -276,7 +310,7 @@ def compute_haplotypes(
     mt = mt.annotate_cols(pop_int=hl.literal(pop_ints).get(gnomad_sa[mt.col_key].pop))
     mt = mt.filter_cols(hl.is_defined(mt.pop_int))
     mt = mt.add_row_index().add_col_index()
-    mt = mt.filter_entries(mt.freq[mt.pop_int].AF >= freq_threshold)
+    mt = mt.filter_entries(mt.freq[mt.pop_int].AF >= variant_freq_threshold)
 
     mt = mt.annotate_rows(
         pops_and_ids_left=hl.agg.filter(
@@ -296,18 +330,20 @@ def compute_haplotypes(
     )
 
     window1 = _get_haplotypes(
-        ht,
-        lambda locus: locus - (locus.position % window_size),
-        1,
-        output_base,
-        pop_ints,
+        ht=ht,
+        windower_f=lambda locus: locus - (locus.position % window_size),
+        idx=1,
+        output_base=output_base,
+        pop_ints=pop_ints,
+        haplotype_freq_threshold=haplotype_freq_threshold,
     )
     window2 = _get_haplotypes(
-        ht,
-        lambda locus: locus - ((locus.position + window_size // 2) % window_size),
-        2,
-        output_base,
-        pop_ints,
+        ht=ht,
+        windower_f=lambda locus: locus - ((locus.position + window_size // 2) % window_size),
+        idx=2,
+        output_base=output_base,
+        pop_ints=pop_ints,
+        haplotype_freq_threshold=haplotype_freq_threshold,
     )
 
     htu = window1.union(window2)

--- a/divref/divref/tools/compute_haplotypes.py
+++ b/divref/divref/tools/compute_haplotypes.py
@@ -36,7 +36,8 @@ def _get_haplotypes(
         idx: Index of this windowing pass (1 or 2), used in the checkpoint filename.
         output_base: Base path for output; checkpoint written to {output_base}.{idx}.ht.
         pop_ints: Mapping from population code to integer index.
-        haplotype_freq_threshold: Minimum haplotype frequency to retain.
+        haplotype_freq_threshold: Minimum estimated gnomAD allele frequency for a haplotype to be
+            retained.
 
     Returns:
         Hail table of haplotypes with empirical frequency summaries.
@@ -218,19 +219,10 @@ def _get_haplotypes(
     )
 
     # Filter out any haplotypes with minimum variant frequency <= 0
-    count_orig: int = hte.count()
-    logger.info(f"{count_orig} haplotypes identified")
-
     hte = hte.filter(hte.min_variant_frequency > 0)
-    count_with_nonzero_freq: int = hte.count()
-    if count_with_nonzero_freq < count_orig:
-        logger.warning(
-            f"Removed {count_orig - count_with_nonzero_freq} haplotypes with "
-            "min_variant_frequency <= 0",
-        )
 
     # Estimate the fraction of phased
-    fraction_phased: float = hte.max_empirical_AF / hte.min_variant_frequency
+    fraction_phased = hte.max_empirical_AF / hte.min_variant_frequency
     hte = hte.annotate(
         fraction_phased=fraction_phased,
         estimated_gnomad_AF=hl.min(

--- a/divref/tests/tools/test_compute_haplotypes.py
+++ b/divref/tests/tools/test_compute_haplotypes.py
@@ -26,7 +26,8 @@ def test_compute_haplotypes(
             gnomad_va_file=in_sites,
             gnomad_sa_file=in_samples,
             window_size=5000,
-            freq_threshold=0.005,
+            variant_freq_threshold=0.005,
+            haplotype_freq_threshold=0.005,
             output_base=output_base,
             temp_dir=tmp_path / "hail_tmp",
         )
@@ -34,7 +35,7 @@ def test_compute_haplotypes(
     # --- assert ---
     result = hl.read_table(f"{output_base}.ht")
     result_count = result.count()
-    assert result_count == 295
+    assert result_count == 33
 
     results: list[hl.Struct] = result.collect()
 

--- a/divref/tests/tools/test_compute_haplotypes.py
+++ b/divref/tests/tools/test_compute_haplotypes.py
@@ -4,14 +4,25 @@ from pathlib import Path
 from unittest.mock import patch
 
 import hail as hl
+import pytest
 
 from divref.tools.compute_haplotypes import compute_haplotypes
 
 
+@pytest.mark.parametrize(
+    "freq_threshold,expected_count",
+    [
+        (0, 2955),
+        (0.005, 33),
+        (1, 0),
+    ],
+)
 def test_compute_haplotypes(
     hail_context: None,  # noqa: ARG001
     datadir: Path,
     tmp_path: Path,
+    freq_threshold: float,
+    expected_count: int,
 ) -> None:
     """Happy-path: compute haplotypes from test VCF with gnomAD annotations."""
     # --- act ---
@@ -26,8 +37,8 @@ def test_compute_haplotypes(
             gnomad_va_file=in_sites,
             gnomad_sa_file=in_samples,
             window_size=5000,
-            variant_freq_threshold=0.005,
-            haplotype_freq_threshold=0.005,
+            variant_freq_threshold=freq_threshold,
+            haplotype_freq_threshold=freq_threshold,
             output_base=output_base,
             temp_dir=tmp_path / "hail_tmp",
         )
@@ -35,7 +46,7 @@ def test_compute_haplotypes(
     # --- assert ---
     result = hl.read_table(f"{output_base}.ht")
     result_count = result.count()
-    assert result_count == 33
+    assert result_count == expected_count
 
     results: list[hl.Struct] = result.collect()
 

--- a/divref/tests/tools/test_compute_haplotypes.py
+++ b/divref/tests/tools/test_compute_haplotypes.py
@@ -10,18 +10,20 @@ from divref.tools.compute_haplotypes import compute_haplotypes
 
 
 @pytest.mark.parametrize(
-    "freq_threshold,expected_count",
+    "variant_freq_threshold,haplotype_freq_threshold,expected_count",
     [
-        (0, 2955),
-        (0.005, 33),
-        (1, 0),
+        (0.0, 0.0, 517),
+        (0.005, 0.0, 295),
+        (0.0, 0.005, 30),
+        (0.005, 0.005, 33),
     ],
 )
 def test_compute_haplotypes(
     hail_context: None,  # noqa: ARG001
     datadir: Path,
     tmp_path: Path,
-    freq_threshold: float,
+    variant_freq_threshold: float,
+    haplotype_freq_threshold: float,
     expected_count: int,
 ) -> None:
     """Happy-path: compute haplotypes from test VCF with gnomAD annotations."""
@@ -37,8 +39,8 @@ def test_compute_haplotypes(
             gnomad_va_file=in_sites,
             gnomad_sa_file=in_samples,
             window_size=5000,
-            variant_freq_threshold=freq_threshold,
-            haplotype_freq_threshold=freq_threshold,
+            variant_freq_threshold=variant_freq_threshold,
+            haplotype_freq_threshold=haplotype_freq_threshold,
             output_base=output_base,
             temp_dir=tmp_path / "hail_tmp",
         )
@@ -61,3 +63,31 @@ def test_compute_haplotypes(
     assert all(hasattr(r, "max_empirical_AC") for r in results)
     assert all(hasattr(r, "all_pop_freqs") for r in results)
     assert all(len(r.all_pop_freqs) > 0 for r in results)
+
+
+def test_compute_haplotypes_no_variants(
+    hail_context: None,  # noqa: ARG001
+    datadir: Path,
+    tmp_path: Path,
+) -> None:
+    """All variants are filtered out."""
+    # --- act ---
+    in_sites = datadir / "chr1_100001_200000.gnomad_afs.ht"
+    in_samples = datadir / "hgdp_1kg_sample_metadata.extract.ht"
+    vcf_path = datadir / "chr1_100001_200000.vcf.gz"
+    output_base = tmp_path / "haplos"
+
+    with (
+        patch("divref.tools.compute_haplotypes.hl.init"),
+        pytest.raises(ValueError, match="No variants found with minimum population AF"),
+    ):
+        compute_haplotypes(
+            vcfs_path=vcf_path,
+            gnomad_va_file=in_sites,
+            gnomad_sa_file=in_samples,
+            window_size=5000,
+            variant_freq_threshold=1,
+            haplotype_freq_threshold=0,
+            output_base=output_base,
+            temp_dir=tmp_path / "hail_tmp",
+        )

--- a/workflows/config/config_schema.yml
+++ b/workflows/config/config_schema.yml
@@ -76,7 +76,9 @@ properties:
     type: number
     minimum: 0
     maximum: 1
-    description: Minimum allele frequency for at least one selected population when running `divref compute-haplotypes`.
+    description: |
+      Minimum allele frequency for a variant in at least one selected population when running 
+      `divref compute-haplotypes`.
     default: 0.005
 
   hgdp_1kg_min_estimated_gnomad_haplotype_af:

--- a/workflows/create_test_data.smk
+++ b/workflows/create_test_data.smk
@@ -156,7 +156,8 @@ rule compute_haplotypes:
                 --gnomad-va-file {input.variant_ht} \
                 --gnomad-sa-file {input.sample_ht} \
                 --window-size {params.window_size} \
-                --freq-threshold {params.freq_threshold} \
+                --variant-freq-threshold {params.freq_threshold} \
+                --haplotype-freq-threshold {params.freq_threshold} \
                 --output-base {params.output_base}
             
             # remove intermediate files

--- a/workflows/generate_divref.smk
+++ b/workflows/generate_divref.smk
@@ -170,7 +170,7 @@ rule compute_haplotypes:
                 --output-base {params.output_base}
             
             # remove intermediate files
-            rm -r {params.output_base}.[12].ht
+            rm -r {params.output_base}.[12].ht {params.output_base}.variants.ht
         ) &> {log}
         """
 

--- a/workflows/generate_divref.smk
+++ b/workflows/generate_divref.smk
@@ -154,7 +154,8 @@ rule compute_haplotypes:
         "logs/generate_divref/compute_haplotypes.{chrom}.log",
     params:
         window_size=HGDP_1KG_HAPLOTYPE_WINDOW_SIZE,
-        freq_threshold=HGDP_1KG_MIN_POP_AF_COMPUTE_HAPLOTYPES,
+        variant_freq_threshold=HGDP_1KG_MIN_POP_AF_COMPUTE_HAPLOTYPES,
+        haplotype_freq_threshold=HGDP_1KG_MIN_EST_GNOMAD_HAPLOTYPE_AF,
         output_base=f"{WORK_DIR}/haplotypes/hgdp_1kg.haplotypes.{{chrom}}",
     shell:
         """
@@ -164,7 +165,8 @@ rule compute_haplotypes:
                 --gnomad-va-file {input.variant_ht} \
                 --gnomad-sa-file {input.sample_ht} \
                 --window-size {params.window_size} \
-                --freq-threshold {params.freq_threshold} \
+                --variant-freq-threshold {params.variant_freq_threshold} \
+                --haplotype-freq-threshold {params.haplotype_freq_threshold} \
                 --output-base {params.output_base}
             
             # remove intermediate files


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Haplotype computation supports separate variant- and haplotype-level frequency thresholds for finer filtering.

* **Chores**
  * Renamed a single frequency parameter to clarify variant-level threshold and introduced a distinct haplotype-level threshold; workflows updated to pass both.

* **Bug Fixes**
  * Now raises a clear error when variant-level filtering removes all variants.

* **Tests**
  * Expanded tests to cover multiple threshold combinations and the no-variants error.

* **Documentation**
  * Clarified schema description for the variant frequency parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->