### PR TITLE
feat: stream chunks for database input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@
 # Snakemake workflow related files
 logs/
 data/
+
+# Scratch data
+scratch/

--- a/divref/divref/tools/create_duckdb_index.py
+++ b/divref/divref/tools/create_duckdb_index.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-import os
+from collections.abc import Iterator
 from pathlib import Path
 
 import duckdb
@@ -45,17 +45,18 @@ def create_duckdb_index(
     version: str,
     reference_genome: str = defaults.REFERENCE_GENOME,
     tmp_dir: Path = Path("/tmp"),
+    polars_chunk_size: int = 500_000,
+    retain_per_contig_tsvs: bool = False,
+    force: bool = False,
 ) -> None:
     """
     Convert per-chr haplotype and gnomAD variant Hail tables into a searchable DuckDB index.
 
-    Reads and annotates the haplotype and gnomAD variant tables one contig at a time, sorting by
-    position within each contig.
-
-    Merges all the per-contig tables together, assigns sequence IDs, generates sequence strings with
-    flanking reference context.
-
-    Writes a DuckDB index file.
+    Streams sequences one contig at a time, then sub-divides each contig at the polars read step:
+    each per-contig TSV is read back in batches of `polars_chunk_size` rows, and each batch is
+    appended to the DuckDB `sequences` table. The first batch creates the table; subsequent
+    batches `INSERT INTO` it. Sequence IDs are assigned with a running offset so they remain
+    unique across contigs and batches.
 
     Args:
         in_table_pairs_tsv: Path to a TSV file with fields 'contig', 'haplotype_table_path', and
@@ -63,21 +64,32 @@ def create_duckdb_index(
         reference_fasta: Path to the indexed reference FASTA for sequence extraction.
         window_size: Window size used when generating haplotypes; used as the context size when
             constructing sequence strings and stored in the index.
-        output_base: Base path for output files. Writes {output_base}.haplotypes.tsv.bgz and
-            {output_base}.haplotypes.index.duckdb.
+        output_base: Base path for output. Writes
+            `{output_base}.haplotypes_gnomad_merge.index.duckdb` and, when
+            `retain_per_contig_tsvs` is True, one
+            `{output_base}.haplotypes_gnomad_merge.{contig}.tsv.bgz` per contig.
         version: Version identifier embedded in sequence IDs (e.g. "1.0").
         reference_genome: Reference genome to use. Defaults to "GRCh38".
-        tmp_dir: Temporary directory for Hail checkpoint files.
+        tmp_dir: Temporary directory for Hail checkpoints and (when not retained) per-contig
+            intermediate TSVs.
+        polars_chunk_size: Maximum number of rows per polars read batch. Bounds the in-process
+            DataFrame size when streaming each per-contig TSV into DuckDB.
+        retain_per_contig_tsvs: If True, write per-contig TSVs alongside the duckdb output rather
+            than into `tmp_dir`.
+        force: If True, overwrite an existing duckdb output. Otherwise raise FileExistsError.
     """
     assert_path_is_readable(in_table_pairs_tsv)
     assert_path_is_readable(reference_fasta)
     assert_path_is_readable(reference_fasta.with_suffix(".fai"))
     assert_directory_exists(tmp_dir)
 
-    # fail fast if output files are not writeable
-    out_table_file: Path = Path(f"{str(output_base)}.haplotypes_gnomad_merge.tsv.bgz")
     out_duckdb_file: Path = Path(f"{str(output_base)}.haplotypes_gnomad_merge.index.duckdb")
-    assert_path_is_writable(out_table_file)
+    if out_duckdb_file.exists():
+        if not force:
+            raise FileExistsError(
+                f"DuckDB output already exists at {out_duckdb_file}. Pass --force to overwrite."
+            )
+        out_duckdb_file.unlink()
     assert_path_is_writable(out_duckdb_file)
 
     table_pairs: list[TablePair] = list(TablePair.read(in_table_pairs_tsv))
@@ -87,27 +99,60 @@ def create_duckdb_index(
         assert_directory_exists(table_pair.haplotype_table_path)
         assert_directory_exists(table_pair.sites_table_path)
 
+    # determine per-contig TSV paths and fail fast on writability when retained
+    per_contig_tsv_dir: Path = output_base.parent if retain_per_contig_tsvs else tmp_dir
+    per_contig_tsvs: dict[str, Path] = {
+        tp.contig: per_contig_tsv_dir
+        / f"{output_base.name}.haplotypes_gnomad_merge.{tp.contig}.tsv.bgz"
+        for tp in table_pairs
+    }
+    if retain_per_contig_tsvs:
+        for tsv_path in per_contig_tsvs.values():
+            assert_path_is_writable(tsv_path)
+
     hl.init(tmp_dir=str(tmp_dir))
 
     pops_legend: list[str] = hl.read_table(str(table_pairs[0].sites_table_path)).pops.collect()[0]
+    hl.get_reference(reference_genome).add_sequence(str(reference_fasta))
 
-    ht = build_sequences_table(
-        table_pairs=table_pairs,
-        reference_fasta=reference_fasta,
-        reference_genome=reference_genome,
-        window_size=window_size,
-        version=version,
-    )
-    df = export_sequences_table_to_dataframe(
-        ht=ht, out_file=out_table_file, pops_legend=pops_legend
-    )
-    write_duckdb_index(
-        df=df,
-        out_file=out_duckdb_file,
-        window_size=window_size,
-        pops_legend=pops_legend,
-        version=version,
-    )
+    with duckdb.connect(str(out_duckdb_file)) as conn:
+        sequence_id_offset: int = 0
+        created_table: bool = False
+        for table_pair in table_pairs:
+            contig_seq_ht = build_contig_sequences_table(
+                table_pair=table_pair,
+                window_size=window_size,
+                version=version,
+                sequence_id_offset=sequence_id_offset,
+            )
+            contig_tsv: Path = per_contig_tsvs[table_pair.contig]
+            export_sequences_table_to_tsv(
+                ht=contig_seq_ht, out_file=contig_tsv, pops_legend=pops_legend
+            )
+
+            contig_rows: int = 0
+            for df in iter_dataframe_chunks(
+                tsv=contig_tsv, pops_legend=pops_legend, chunk_size=polars_chunk_size
+            ):
+                if not created_table:
+                    conn.execute("CREATE TABLE sequences AS SELECT * FROM df")
+                    created_table = True
+                else:
+                    conn.execute("INSERT INTO sequences SELECT * FROM df")
+                contig_rows += df.height
+                sequence_id_offset += df.height
+
+            logger.info(
+                f"Appended {contig_rows} rows for contig {table_pair.contig} "
+                f"(running total: {sequence_id_offset})"
+            )
+
+        conn.execute("CREATE INDEX idx_sequence_id ON sequences(sequence_id)")
+        conn.execute("CREATE TABLE window_size AS SELECT ? AS window_size", [window_size])
+        conn.execute(
+            "CREATE TABLE pops_legend AS SELECT ? AS pops_legend", [json.dumps(pops_legend)]
+        )
+        conn.execute("CREATE TABLE VERSION AS SELECT ? AS version", [version])
 
 
 def build_hgdp_haplotype_table_entries(
@@ -191,44 +236,37 @@ def build_gnomad_variant_table_entries(sites_table_path: Path) -> hl.Table:
     return va
 
 
-def build_sequences_table(
-    table_pairs: list[TablePair],
-    reference_fasta: Path,
-    reference_genome: str,
+def build_contig_sequences_table(
+    *,
+    table_pair: TablePair,
     window_size: int,
     version: str,
+    sequence_id_offset: int,
 ) -> hl.Table:
     """
-    Build the "sequences" table input with sequences and variant strings.
+    Build the per-contig sequences hail table with sequences, coordinates, and IDs.
 
-    Prepares and annotates the haplotype and gnomAD tables, assigns sequence IDs, and generates
-    sequences with flanking reference context.
+    Reads the HGDP haplotype + gnomAD sites tables for one contig, unions them, sorts by genomic
+    position, and applies the same per-row annotations as the cross-contig table. Sequence IDs are
+    offset by `sequence_id_offset` so they remain unique across contigs.
 
     Args:
-        table_pairs: List of table pairs by contig. Sequences will be sorted by reference genome
-            start position within each contig; contigs will be ordered as input.
-        reference_fasta: Path to the reference FASTA.
-        reference_genome: Reference genome to use.
+        table_pair: Per-contig pair of haplotype + gnomAD sites table paths.
         window_size: Context size for sequence construction and haplotype splitting.
         version: Version identifier for sequence IDs.
+        sequence_id_offset: Number of rows already written for prior contigs; added to this
+            contig's local index to produce a globally unique sequence ID.
 
     Returns:
         Hail table with sequences, coordinates, and variant strings annotated.
     """
-    hl.get_reference(reference_genome).add_sequence(str(reference_fasta))
-
-    sequences_tables: list[hl.Table] = []
-    for table_pair in table_pairs:
-        hgdp_haplotypes_ht: hl.Table = build_hgdp_haplotype_table_entries(
-            haplotypes_table_path=table_pair.haplotype_table_path, window_size=window_size
-        )
-        gnomad_variants_ht: hl.Table = build_gnomad_variant_table_entries(
-            sites_table_path=table_pair.sites_table_path
-        )
-        contig_seq_ht: hl.Table = hgdp_haplotypes_ht.union(gnomad_variants_ht, unify=True)
-        sequences_tables.append(contig_seq_ht)
-
-    seq_ht: hl.Table = sequences_tables[0].union(*sequences_tables[1:])
+    hgdp_haplotypes_ht: hl.Table = build_hgdp_haplotype_table_entries(
+        haplotypes_table_path=table_pair.haplotype_table_path, window_size=window_size
+    )
+    gnomad_variants_ht: hl.Table = build_gnomad_variant_table_entries(
+        sites_table_path=table_pair.sites_table_path
+    )
+    seq_ht: hl.Table = hgdp_haplotypes_ht.union(gnomad_variants_ht, unify=True)
 
     seq_ht = seq_ht.rename({
         "max_empirical_AF": "popmax_empirical_AF",
@@ -236,9 +274,9 @@ def build_sequences_table(
     })
 
     seq_ht = seq_ht.annotate(
-        min_locus=hl.sorted(seq_ht.variants, key=lambda v: v.locus.position)[0].locus
+        min_pos=hl.sorted(seq_ht.variants, key=lambda v: v.locus.position)[0].locus.position
     )
-    seq_ht = seq_ht.order_by(seq_ht.min_locus).drop("min_locus")
+    seq_ht = seq_ht.order_by(seq_ht.min_pos).drop("min_pos")
     seq_ht = seq_ht.add_index()
     coords = haplo_coordinates(window_size, seq_ht.variants)
     seq_ht = seq_ht.annotate(
@@ -250,28 +288,25 @@ def build_sequences_table(
     seq_ht = seq_ht.annotate(variant_strs=seq_ht.variants.map(lambda x: hl.variant_str(x)))
     seq_ht = seq_ht.annotate(
         sequence_length=hl.len(seq_ht.sequence),
-        sequence_id=hl.str(f"DR-{version}-") + hl.str(seq_ht.idx),
+        sequence_id=hl.str(f"DR-{version}-") + hl.str(seq_ht.idx + sequence_id_offset),
         n_variants=hl.len(seq_ht.variants),
     ).drop("idx")
 
     return seq_ht
 
 
-def export_sequences_table_to_dataframe(
+def export_sequences_table_to_tsv(
     ht: hl.Table,
     out_file: Path,
     pops_legend: list[str],
-) -> polars.DataFrame:
+) -> None:
     """
-    Export the sequences Hail table to a TSV file and return it as a polars DataFrame.
+    Export the sequences Hail table to a single bgz-compressed TSV.
 
     Args:
         ht: Annotated haplotype/variant table with sequences and variant strings.
         out_file: Path for the output TSV file.
         pops_legend: Ordered list of population codes for frequency columns.
-
-    Returns:
-        Polars DataFrame read back from the exported TSV.
     """
     ht.select(
         "sequence",
@@ -296,41 +331,42 @@ def export_sequences_table_to_dataframe(
         },
     ).export(str(out_file))
 
+
+def iter_dataframe_chunks(
+    *,
+    tsv: Path,
+    pops_legend: list[str],
+    chunk_size: int,
+) -> Iterator[polars.DataFrame]:
+    """
+    Yield polars DataFrames of up to `chunk_size` rows from a sequences TSV.
+
+    The `sequence_id` and `gnomAD_AF_*` columns are explicitly typed as strings so that
+    schema inference cannot misread comma-delimited per-variant AFs as floats.
+
+    Args:
+        tsv: Path to the sequences TSV (bgz-compressed).
+        pops_legend: Ordered list of population codes used to name `gnomAD_AF_{pop}` columns.
+        chunk_size: Maximum rows per yielded DataFrame.
+
+    Yields:
+        Polars DataFrame batches read from `tsv`.
+    """
     schema_overrides: dict[str, type[polars.DataType]] = {
         "sequence_id": polars.String,
         **{f"gnomAD_AF_{pop}": polars.String for pop in pops_legend},
     }
-    return polars.read_csv(
-        out_file,
+    reader = polars.read_csv_batched(
+        tsv,
         separator="\t",
         schema_overrides=schema_overrides,
         null_values="null",
+        batch_size=chunk_size,
     )
-
-
-def write_duckdb_index(
-    df: polars.DataFrame,  # noqa: ARG001 — accessed by DuckDB via SQL `FROM df`
-    out_file: Path,
-    window_size: int,
-    pops_legend: list[str],
-    version: str,
-) -> None:
-    """
-    Create a DuckDB index database from the haplotype DataFrame.
-
-    Args:
-        df: DataFrame with sequence and metadata columns.
-        out_file: Path for the output .duckdb file.
-        window_size: Window size to store in the index.
-        pops_legend: Population legend list to store in the index.
-        version: Version string to store in the index.
-    """
-    if os.path.exists(out_file):
-        os.remove(out_file)
-    con = duckdb.connect(str(out_file))
-    con.execute("CREATE TABLE sequences AS SELECT * FROM df")
-    con.execute("CREATE INDEX idx_sequence_id ON sequences(sequence_id)")
-    con.execute("CREATE TABLE window_size AS SELECT ? AS window_size", [window_size])
-    con.execute("CREATE TABLE pops_legend AS SELECT ? AS pops_legend", [json.dumps(pops_legend)])
-    con.execute("CREATE TABLE VERSION AS SELECT ? AS version", [version])
-    con.close()
+    while True:
+        batches = reader.next_batches(1)
+        if not batches:
+            return
+        for df in batches:
+            if df.height > 0:
+                yield df

--- a/divref/divref/tools/create_duckdb_index.py
+++ b/divref/divref/tools/create_duckdb_index.py
@@ -150,6 +150,9 @@ def create_duckdb_index(
                 f"(running total: {sequence_id_offset})"
             )
 
+        if not created_table:
+            raise ValueError("No sequence rows were produced; cannot create DuckDB index.")
+
         conn.execute("CREATE INDEX idx_sequence_id ON sequences(sequence_id)")
         conn.execute("CREATE TABLE window_size AS SELECT ? AS window_size", [window_size])
         conn.execute(

--- a/divref/divref/tools/create_duckdb_index.py
+++ b/divref/divref/tools/create_duckdb_index.py
@@ -142,6 +142,9 @@ def create_duckdb_index(
                 contig_rows += df.height
                 sequence_id_offset += df.height
 
+            if not retain_per_contig_tsvs and contig_tsv.exists():
+                contig_tsv.unlink()
+
             logger.info(
                 f"Appended {contig_rows} rows for contig {table_pair.contig} "
                 f"(running total: {sequence_id_offset})"

--- a/divref/divref/tools/create_duckdb_index.py
+++ b/divref/divref/tools/create_duckdb_index.py
@@ -36,7 +36,7 @@ class TablePair(Metric):
     sites_table_path: Path
 
 
-def create_duckdb_index(
+def create_duckdb_index(  # noqa: C901
     *,
     in_table_pairs_tsv: Path,
     reference_fasta: Path,

--- a/divref/divref/tools/create_duckdb_index.py
+++ b/divref/divref/tools/create_duckdb_index.py
@@ -356,17 +356,12 @@ def iter_dataframe_chunks(
         "sequence_id": polars.String,
         **{f"gnomAD_AF_{pop}": polars.String for pop in pops_legend},
     }
-    reader = polars.read_csv_batched(
+    lf = polars.scan_csv(
         tsv,
         separator="\t",
         schema_overrides=schema_overrides,
         null_values="null",
-        batch_size=chunk_size,
     )
-    while True:
-        batches = reader.next_batches(1)
-        if not batches:
-            return
-        for df in batches:
-            if df.height > 0:
-                yield df
+    for df in lf.collect_batches(chunk_size=chunk_size):
+        if df.height > 0:
+            yield df

--- a/divref/divref/tools/create_duckdb_index.py
+++ b/divref/divref/tools/create_duckdb_index.py
@@ -45,7 +45,7 @@ def create_duckdb_index(
     version: str,
     reference_genome: str = defaults.REFERENCE_GENOME,
     tmp_dir: Path = Path("/tmp"),
-    polars_chunk_size: int = 500_000,
+    polars_chunk_size: int = 100_000,
     retain_per_contig_tsvs: bool = False,
     force: bool = False,
 ) -> None:

--- a/workflows/config/config_schema.yml
+++ b/workflows/config/config_schema.yml
@@ -90,6 +90,14 @@ properties:
     description: Version identifier for output resource.
     example: 1.0
 
+  polars_chunk_size:
+    type: integer
+    minimum: 10000
+    description: |
+      Number of sequence table rows to read from intermediate TSV file and insert into database at a
+      time. Recommended maximum 1,000,000 for typical laptop.
+    defualt: 500000
+
   work_dir:
     type: string
     description: Path to the working directory for intermediate files.

--- a/workflows/config/config_schema.yml
+++ b/workflows/config/config_schema.yml
@@ -96,7 +96,7 @@ properties:
     description: |
       Number of sequence table rows to read from intermediate TSV file and insert into database at a
       time. Recommended maximum 1,000,000 for typical laptop.
-    defualt: 500000
+    default: 100000
 
   work_dir:
     type: string

--- a/workflows/generate_divref.smk
+++ b/workflows/generate_divref.smk
@@ -40,6 +40,7 @@ HGDP_1KG_MIN_POP_HAPLOTYPE_AF: float = config["hgdp_1kg_min_estimated_gnomad_hap
 HGDP_1KG_HAPLOTYPE_WINDOW_SIZE: int = config["hgdp_1kg_haplotype_window_size"]
 
 SEQUENCE_WINDOW_SIZE: int = config["sequence_window_size"]
+POLARS_CHUNK_SIZE: int = config["polars_chunk_size"]
 
 VCF_EXTS: list[str] = [".vcf.gz", ".vcf.gz.tbi"]
 
@@ -246,6 +247,7 @@ rule create_divref_index:
         window_size=SEQUENCE_WINDOW_SIZE,
         output_base=f"{WORK_DIR}/output/hgdp_1kg",
         version=VERSION,
+        polars_chunk_size=POLARS_CHUNK_SIZE,
         tmp_dir=TMP_DIR,
     shell:
         """
@@ -256,6 +258,7 @@ rule create_divref_index:
                 --window-size {params.window_size} \
                 --output-base {params.output_base} \
                 --version {params.version} \
+                --polars-chunk-size {params.polars_chunk_size} \
                 --tmp-dir {params.tmp_dir}
         ) &> {log}
         """


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable batch-size parameter for DuckDB index creation (default: 100,000 rows).
  * Added force flag to overwrite existing index files.
  * Added option to retain intermediate data files.

* **Improvements**
  * Optimized memory usage by processing sequence data in streaming batches instead of loading entirely into memory.

* **Chores**
  * Updated git ignore rules to exclude scratch directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->