### PR TITLE
feat: add rules for getting the gnomAD variants from a different source than the HGDP+1KG haplotypes

### DIFF
--- a/workflows/config/config.yml
+++ b/workflows/config/config.yml
@@ -1,2 +1,2 @@
-chromosomes: ["chr20", "chr21", "chr22"]
+chromosomes: ["chr1", "chr20", "chr21", "chr22"]
 version: "0.1-dev"

--- a/workflows/config/config_schema.yml
+++ b/workflows/config/config_schema.yml
@@ -77,6 +77,27 @@ properties:
     description: Window size in bp for grouping variants into haplotypes.
     default: 100
 
+  gnomad_variant_annotation_source:
+    type: string
+    description: |
+      Source of the gnomAD variant annotations Hail table. Supported options:
+      JOINT_41 = v4.1 joint exomes (730K) + genomes (76K)
+        gs://gcp-public-data--gnomad/release/4.1/ht/joint/gnomad.joint.v4.1.sites.ht
+      GENOMES_312 = v3.1.2 genomes (76K)
+        gs://gcp-public-data--gnomad/release/3.1.2/ht/genomes/gnomad.genomes.v3.1.2.sites.ht
+      HGDP_1KG_312 = v3.1.2 HGDP+1KG subset genomes (4K, uses frequencies from genomes 76K)
+        gs://gcp-public-data--gnomad/release/3.1.2/ht/genomes/gnomad.genomes.v3.1.2.hgdp_1kg_subset_variant_annotations.ht
+    default: "JOINT_41"
+
+  gnomad_variant_min_pop_variant_allele_freq:
+    type: number
+    minimum: 0
+    maximum: 1
+    description: |
+      Minimum variant allele frequency for at least one selected population when running
+      `divref extract-gnomad-single-afs`.
+    default: 0.005
+
   sequence_window_size:
     type: integer
     description: |

--- a/workflows/config/config_schema.yml
+++ b/workflows/config/config_schema.yml
@@ -79,6 +79,7 @@ properties:
 
   gnomad_variant_annotation_source:
     type: string
+    enum: ["JOINT_41", "GENOMES_312", "HGDP_1KG_312"]
     description: |
       Source of the gnomAD variant annotations Hail table. Supported options:
       JOINT_41 = v4.1 joint exomes (730K) + genomes (76K)

--- a/workflows/generate_divref.smk
+++ b/workflows/generate_divref.smk
@@ -39,6 +39,10 @@ HGDP_1KG_MIN_POP_VARIANT_AF: float = config["hgdp_1kg_min_pop_variant_allele_fre
 HGDP_1KG_MIN_POP_HAPLOTYPE_AF: float = config["hgdp_1kg_min_estimated_gnomad_haplotype_allele_freq"]
 HGDP_1KG_HAPLOTYPE_WINDOW_SIZE: int = config["hgdp_1kg_haplotype_window_size"]
 
+# gnomAD variants can be from a different source than the haplotypes
+GNOMAD_VARIANT_ANNOTATION_SOURCE: str = config["gnomad_variant_annotation_source"]
+GNOMAD_VARIANT_MIN_POP_VARIANT_AF: float = config["gnomad_variant_min_pop_variant_allele_freq"]
+
 SEQUENCE_WINDOW_SIZE: int = config["sequence_window_size"]
 POLARS_CHUNK_SIZE: int = config["polars_chunk_size"]
 
@@ -169,6 +173,32 @@ rule compute_haplotypes:
 
 
 ####################################################################################################
+# Extracts allele frequencies from the gnomAD sites table for the given populations and subsets to
+# sites over the specified minimum allele frequency in at least one population.
+####################################################################################################
+rule extract_gnomad_variant_afs:
+    output:
+        variant_ht=directory(f"{WORK_DIR}/inputs/gnomad.sites.{{chrom}}.ht"),
+    log:
+        "logs/generate_divref/extract_gnomad_variant_afs.{chrom}.log",
+    params:
+        gnomad_source=GNOMAD_VARIANT_ANNOTATION_SOURCE,
+        freq_threshold=GNOMAD_VARIANT_MIN_POP_VARIANT_AF,
+        populations=" ".join(POPS),
+    shell:
+        """
+        (
+            divref extract-gnomad-single-afs \
+                --in-gnomad-version {params.gnomad_source} \
+                --contig {wildcards.chrom} \
+                --freq-threshold {params.freq_threshold} \
+                --out-sites-hail-table {output.variant_ht} \
+                --populations {params.populations} \
+        ) &> {log}
+        """
+
+
+####################################################################################################
 # Downloads and unzips the reference genome.
 ####################################################################################################
 rule download_reference_genome:
@@ -217,7 +247,7 @@ rule create_table_pairs_tsv:
             chrom=CHROMS,
         ),
         sites_hts=expand(
-            f"{WORK_DIR}/inputs/hgdp_1kg.sites.{{chrom}}.ht",
+            f"{WORK_DIR}/inputs/gnomad.sites.{{chrom}}.ht",
             chrom=CHROMS,
         ),
     output:
@@ -227,7 +257,7 @@ rule create_table_pairs_tsv:
             f.write("contig\thaplotype_table_path\tsites_table_path\n")
             for chrom in CHROMS:
                 haplotype_ht = f"{WORK_DIR}/haplotypes/hgdp_1kg.haplotypes.{chrom}.ht"
-                sites_ht = f"{WORK_DIR}/inputs/hgdp_1kg.sites.{chrom}.ht"
+                sites_ht = f"{WORK_DIR}/inputs/gnomad.sites.{chrom}.ht"
                 f.write(f"{chrom}\t{haplotype_ht}\t{sites_ht}\n")
 
 

--- a/workflows/generate_divref.smk
+++ b/workflows/generate_divref.smk
@@ -189,7 +189,7 @@ rule extract_gnomad_variant_afs:
         """
         (
             divref extract-gnomad-single-afs \
-                --in-gnomad-version {params.gnomad_source} \
+                --gnomad-version {params.gnomad_source} \
                 --contig {wildcards.chrom} \
                 --freq-threshold {params.freq_threshold} \
                 --out-sites-hail-table {output.variant_ht} \

--- a/workflows/generate_divref.smk
+++ b/workflows/generate_divref.smk
@@ -193,7 +193,7 @@ rule extract_gnomad_variant_afs:
                 --contig {wildcards.chrom} \
                 --freq-threshold {params.freq_threshold} \
                 --out-sites-hail-table {output.variant_ht} \
-                --populations {params.populations} \
+                --populations {params.populations}
         ) &> {log}
         """
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable gnomAD variant allele frequency extraction with selectable annotation sources and minimum population frequency filtering.
  * New workflow parameters enable customization of gnomAD data extraction (source defaults to JOINT_41, minimum frequency defaults to 0.005) during reference generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->