### PR TITLE
feat: allow different population lists for HGDP haplotype and gnomAD variant inputs

### DIFF
--- a/divref/divref/tools/compute_haplotypes.py
+++ b/divref/divref/tools/compute_haplotypes.py
@@ -364,5 +364,6 @@ def compute_haplotypes(
     )
 
     htu = window1.union(window2)
+    htu = htu.annotate_globals(pops=hl.literal(pop_legend))
     logger.info("Writing final %s.ht ...", output_base)
     htu.key_by("haplotype").naive_coalesce(64).write(f"{str(output_base)}.ht", overwrite=True)

--- a/divref/divref/tools/create_duckdb_index.py
+++ b/divref/divref/tools/create_duckdb_index.py
@@ -61,6 +61,13 @@ def create_duckdb_index(  # noqa: C901
     batches `INSERT INTO` it. Sequence IDs are assigned with a running offset so they remain
     unique across contigs and batches.
 
+    The two input sources may carry different population legends (e.g. when the gnomAD variant
+    track is drawn from a release with more populations than the HGDP haplotype track). Both per-
+    source pop-index spaces are remapped into a single `joint_pops_legend` (the union of the two,
+    with gnomAD pops first) before union, so the `max_pop` and `all_pop_freqs[*].pop` integers in
+    the index are comparable across sources. The DuckDB output stores three legend tables:
+    `hgdp_haplotype_pops_legend`, `gnomad_variant_pops_legend`, and `joint_pops_legend`.
+
     Args:
         in_table_pairs_tsv: Path to a TSV file with fields 'contig', 'haplotype_table_path', and
             'sites_table_path'.
@@ -131,7 +138,26 @@ def create_duckdb_index(  # noqa: C901
     )
     hl.init(tmp_dir=str(tmp_dir))
 
-    pops_legend: list[str] = hl.read_table(str(table_pairs[0].sites_table_path)).pops.collect()[0]
+    hgdp_pops_legend: list[str] = hl.read_table(
+        str(table_pairs[0].haplotype_table_path)
+    ).pops.collect()[0]
+    gnomad_pops_legend: list[str] = hl.read_table(
+        str(table_pairs[0].sites_table_path)
+    ).pops.collect()[0]
+    # Joint legend: gnomAD pops in their original order, then any HGDP-only pops appended.
+    joint_pops_legend: list[str] = list(gnomad_pops_legend) + [
+        p for p in hgdp_pops_legend if p not in gnomad_pops_legend
+    ]
+    hgdp_to_joint: list[int] = [joint_pops_legend.index(p) for p in hgdp_pops_legend]
+    gnomad_to_joint: list[int] = [joint_pops_legend.index(p) for p in gnomad_pops_legend]
+    # Inverse remaps for reshuffling each source's `gnomad_freqs` inner array into joint order.
+    hgdp_at_joint: list[int] = [
+        hgdp_pops_legend.index(p) if p in hgdp_pops_legend else -1 for p in joint_pops_legend
+    ]
+    gnomad_at_joint: list[int] = [
+        gnomad_pops_legend.index(p) if p in gnomad_pops_legend else -1 for p in joint_pops_legend
+    ]
+
     hl.get_reference(reference_genome).add_sequence(str(reference_fasta))
 
     with duckdb.connect(str(out_duckdb_file)) as conn:
@@ -143,15 +169,23 @@ def create_duckdb_index(  # noqa: C901
                 window_size=window_size,
                 version=version,
                 sequence_id_offset=sequence_id_offset,
+                hgdp_to_joint=hgdp_to_joint,
+                gnomad_to_joint=gnomad_to_joint,
+                hgdp_at_joint=hgdp_at_joint,
+                gnomad_at_joint=gnomad_at_joint,
             )
             contig_tsv: Path = per_contig_tsvs[table_pair.contig]
             export_sequences_table_to_tsv(
-                ht=contig_seq_ht, out_file=contig_tsv, pops_legend=pops_legend
+                ht=contig_seq_ht,
+                out_file=contig_tsv,
+                joint_pops_legend=joint_pops_legend,
             )
 
             contig_rows: int = 0
             for df in iter_dataframe_chunks(
-                tsv=contig_tsv, pops_legend=pops_legend, chunk_size=polars_chunk_size
+                tsv=contig_tsv,
+                joint_pops_legend=joint_pops_legend,
+                chunk_size=polars_chunk_size,
             ):
                 if not created_table:
                     conn.execute("CREATE TABLE sequences AS SELECT * FROM df")
@@ -175,7 +209,16 @@ def create_duckdb_index(  # noqa: C901
         conn.execute("CREATE INDEX idx_sequence_id ON sequences(sequence_id)")
         conn.execute("CREATE TABLE window_size AS SELECT ? AS window_size", [window_size])
         conn.execute(
-            "CREATE TABLE pops_legend AS SELECT ? AS pops_legend", [json.dumps(pops_legend)]
+            "CREATE TABLE hgdp_haplotype_pops_legend AS SELECT ? AS pops_legend",
+            [json.dumps(hgdp_pops_legend)],
+        )
+        conn.execute(
+            "CREATE TABLE gnomad_variant_pops_legend AS SELECT ? AS pops_legend",
+            [json.dumps(gnomad_pops_legend)],
+        )
+        conn.execute(
+            "CREATE TABLE joint_pops_legend AS SELECT ? AS pops_legend",
+            [json.dumps(joint_pops_legend)],
         )
         conn.execute("CREATE TABLE VERSION AS SELECT ? AS version", [version])
 
@@ -183,16 +226,25 @@ def create_duckdb_index(  # noqa: C901
 def build_hgdp_haplotype_table_entries(
     haplotypes_table_path: Path,
     window_size: int,
+    hgdp_to_joint: list[int],
+    hgdp_at_joint: list[int],
 ) -> hl.Table:
     """
     Build HGDP_haplotype entries for the "sequences" table.
 
     Reads the haplotype table, splits the haplotypes by window size, and annotates with source and
-    population frequencies.
+    population frequencies. `max_pop` and `all_pop_freqs[*].pop` integer indices are remapped from
+    the haplotype table's native pop ordering into the joint pop legend, and each row's
+    `gnomad_freqs` inner array is reshuffled and padded to the joint legend's length so it indexes
+    positionally by the joint legend (missing pops become a missing struct).
 
     Args:
         haplotypes_table_path: Path to the computed haplotypes Hail table.
         window_size: Context size for sequence construction and haplotype splitting.
+        hgdp_to_joint: For each index `i` in the haplotype table's pop legend, the corresponding
+            index in the joint pop legend.
+        hgdp_at_joint: For each index `j` in the joint pop legend, the corresponding index in the
+            haplotype table's pop legend, or `-1` if that pop is not present on the haplotype side.
 
     Returns:
         Hail table with added sequences and variant strings.
@@ -216,25 +268,56 @@ def build_hgdp_haplotype_table_entries(
         f"window size {window_size}"
     )
 
-    # Annotate
+    # Annotate; remap pop integers from the haplotype-source legend into the joint legend, and
+    # reshuffle each row's gnomad_freqs inner array into joint legend order with missing-padding.
+    hgdp_remap = hl.literal(hgdp_to_joint)
+    hgdp_at_joint_lit = hl.literal(hgdp_at_joint)
+    inner_struct_type = ht.gnomad_freqs.dtype.element_type.element_type
     ht = ht.annotate(
         source="HGDP_haplotype",
+        max_pop=hgdp_remap[ht.max_pop],
         all_pop_freqs=ht.all_pop_freqs.map(
-            lambda x: hl.struct(pop=x.pop, empirical_AC=x.empirical_AC, empirical_AF=x.empirical_AF)
+            lambda x: hl.struct(
+                pop=hgdp_remap[x.pop],
+                empirical_AC=x.empirical_AC,
+                empirical_AF=x.empirical_AF,
+            )
+        ),
+        gnomad_freqs=ht.gnomad_freqs.map(
+            lambda inner: hl.range(hl.len(hgdp_at_joint_lit)).map(
+                lambda j: hl.if_else(
+                    hgdp_at_joint_lit[j] >= 0,
+                    inner[hgdp_at_joint_lit[j]],
+                    hl.missing(inner_struct_type),
+                )
+            )
         ),
     )
 
     return ht
 
 
-def build_gnomad_variant_table_entries(sites_table_path: Path) -> hl.Table:
+def build_gnomad_variant_table_entries(
+    sites_table_path: Path,
+    gnomad_to_joint: list[int],
+    gnomad_at_joint: list[int],
+) -> hl.Table:
     """
     Build gnomAD_variant entries for the "sequences" table.
 
-    Reads the gnomAD table and annotates entries to match the HGDP_haplotype entries.
+    Reads the gnomAD table and annotates entries to match the HGDP_haplotype entries. `max_pop`
+    and `all_pop_freqs[*].pop` integer indices are remapped from the gnomAD-source legend into the
+    joint pop legend, and the per-variant `gnomad_freqs` inner array is reshuffled and padded to
+    the joint legend's length so it indexes positionally by the joint legend (missing pops become
+    a missing struct).
 
     Args:
         sites_table_path: Path to the gnomAD variant annotations Hail table.
+        gnomad_to_joint: For each index `i` in the gnomAD sites table's pop legend, the
+            corresponding index in the joint pop legend.
+        gnomad_at_joint: For each index `j` in the joint pop legend, the corresponding index in
+            the gnomAD sites table's pop legend, or `-1` if that pop is not present on the gnomAD
+            side.
 
     Returns:
         Tuple of (checkpointed Hail table, population legend list).
@@ -246,22 +329,32 @@ def build_gnomad_variant_table_entries(sites_table_path: Path) -> hl.Table:
     va = va.rename({"pop_freqs": "gnomad_freqs"})
     va = va.key_by()
     argmax_pop = hl.argmax(va.gnomad_freqs.map(lambda x: x.AF))
+    gnomad_remap = hl.literal(gnomad_to_joint)
+    gnomad_at_joint_lit = hl.literal(gnomad_at_joint)
+    inner_struct_type = va.gnomad_freqs.dtype.element_type
+    gnomad_freqs_joint = hl.range(hl.len(gnomad_at_joint_lit)).map(
+        lambda j: hl.if_else(
+            gnomad_at_joint_lit[j] >= 0,
+            va.gnomad_freqs[gnomad_at_joint_lit[j]],
+            hl.missing(inner_struct_type),
+        )
+    )
     va = va.select(
-        max_pop=argmax_pop,
+        max_pop=gnomad_remap[argmax_pop],
         max_empirical_AF=va.gnomad_freqs[argmax_pop].AF,
         fraction_phased=1.0,
         estimated_gnomad_AF=va.gnomad_freqs[argmax_pop].AF,
         max_empirical_AC=va.gnomad_freqs[argmax_pop].AC,
         all_pop_freqs=hl.range(hl.len(va.gnomad_freqs)).map(
             lambda i: hl.struct(
-                pop=i,
+                pop=gnomad_remap[i],
                 empirical_AC=va.gnomad_freqs[i].AC,
                 empirical_AF=va.gnomad_freqs[i].AF,
             )
         ),
         source="gnomAD_variant",
         variants=[hl.struct(locus=va.locus, alleles=va.alleles)],
-        gnomad_freqs=[va.gnomad_freqs],
+        gnomad_freqs=[gnomad_freqs_joint],
     )
     return va
 
@@ -272,6 +365,10 @@ def build_contig_sequences_table(
     window_size: int,
     version: str,
     sequence_id_offset: int,
+    hgdp_to_joint: list[int],
+    gnomad_to_joint: list[int],
+    hgdp_at_joint: list[int],
+    gnomad_at_joint: list[int],
 ) -> hl.Table:
     """
     Build the per-contig sequences hail table with sequences, coordinates, and IDs.
@@ -286,15 +383,24 @@ def build_contig_sequences_table(
         version: Version identifier for sequence IDs.
         sequence_id_offset: Number of rows already written for prior contigs; added to this
             contig's local index to produce a globally unique sequence ID.
+        hgdp_to_joint: Remap from the haplotype-source pop legend into the joint pop legend.
+        gnomad_to_joint: Remap from the gnomAD-source pop legend into the joint pop legend.
+        hgdp_at_joint: Inverse remap: for each joint index, the haplotype-source index or -1.
+        gnomad_at_joint: Inverse remap: for each joint index, the gnomAD-source index or -1.
 
     Returns:
         Hail table with sequences, coordinates, and variant strings annotated.
     """
     hgdp_haplotypes_ht: hl.Table = build_hgdp_haplotype_table_entries(
-        haplotypes_table_path=table_pair.haplotype_table_path, window_size=window_size
+        haplotypes_table_path=table_pair.haplotype_table_path,
+        window_size=window_size,
+        hgdp_to_joint=hgdp_to_joint,
+        hgdp_at_joint=hgdp_at_joint,
     )
     gnomad_variants_ht: hl.Table = build_gnomad_variant_table_entries(
-        sites_table_path=table_pair.sites_table_path
+        sites_table_path=table_pair.sites_table_path,
+        gnomad_to_joint=gnomad_to_joint,
+        gnomad_at_joint=gnomad_at_joint,
     )
     seq_ht: hl.Table = hgdp_haplotypes_ht.union(gnomad_variants_ht, unify=True)
 
@@ -328,15 +434,21 @@ def build_contig_sequences_table(
 def export_sequences_table_to_tsv(
     ht: hl.Table,
     out_file: Path,
-    pops_legend: list[str],
+    joint_pops_legend: list[str],
 ) -> None:
     """
     Export the sequences Hail table to a single bgz-compressed TSV.
 
+    One `gnomAD_AF_{pop}` column is emitted per pop in `joint_pops_legend`, in order. Each row's
+    `gnomad_freqs` inner array is already reshuffled to the joint legend at source-table
+    construction time (with missing-padding for pops absent from a source), so a uniform
+    positional lookup is safe regardless of which source the row came from.
+
     Args:
         ht: Annotated haplotype/variant table with sequences and variant strings.
         out_file: Path for the output TSV file.
-        pops_legend: Ordered list of population codes for frequency columns.
+        joint_pops_legend: Ordered list of all population codes across both input sources; used to
+            resolve `max_pop` integer indices to labels and to name `gnomAD_AF_{pop}` columns.
     """
     ht.select(
         "sequence",
@@ -351,13 +463,13 @@ def export_sequences_table_to_tsv(
         "estimated_gnomad_AF",
         "fraction_phased",
         "source",
-        max_pop=hl.literal(pops_legend)[ht.max_pop],
+        max_pop=hl.literal(joint_pops_legend)[ht.max_pop],
         variants=hl.delimit(ht.variant_strs, ","),
         **{
             f"gnomAD_AF_{pop}": hl.delimit(
                 ht.gnomad_freqs.map(lambda x, _i=i: hl.format("%.5f", x[_i].AF)), ","
             )
-            for i, pop in enumerate(pops_legend)
+            for i, pop in enumerate(joint_pops_legend)
         },
     ).export(str(out_file))
 
@@ -365,7 +477,7 @@ def export_sequences_table_to_tsv(
 def iter_dataframe_chunks(
     *,
     tsv: Path,
-    pops_legend: list[str],
+    joint_pops_legend: list[str],
     chunk_size: int,
 ) -> Iterator[polars.DataFrame]:
     """
@@ -376,7 +488,8 @@ def iter_dataframe_chunks(
 
     Args:
         tsv: Path to the sequences TSV (bgz-compressed).
-        pops_legend: Ordered list of population codes used to name `gnomAD_AF_{pop}` columns.
+        joint_pops_legend: Ordered list of population codes used to name `gnomAD_AF_{pop}`
+            columns; must match what `export_sequences_table_to_tsv` wrote.
         chunk_size: Maximum rows per yielded DataFrame.
 
     Yields:
@@ -384,7 +497,7 @@ def iter_dataframe_chunks(
     """
     schema_overrides: dict[str, type[polars.DataType]] = {
         "sequence_id": polars.String,
-        **{f"gnomAD_AF_{pop}": polars.String for pop in pops_legend},
+        **{f"gnomAD_AF_{pop}": polars.String for pop in joint_pops_legend},
     }
     lf = polars.scan_csv(
         tsv,

--- a/divref/divref/tools/create_duckdb_index.py
+++ b/divref/divref/tools/create_duckdb_index.py
@@ -114,6 +114,8 @@ def create_duckdb_index(  # noqa: C901
     assert_path_is_writable(out_duckdb_file)
 
     table_pairs: list[TablePair] = list(TablePair.read(in_table_pairs_tsv))
+    if not table_pairs:
+        raise ValueError(f"No table pairs found in {in_table_pairs_tsv}.")
 
     # fail fast on input Hail tables
     for table_pair in table_pairs:
@@ -144,6 +146,17 @@ def create_duckdb_index(  # noqa: C901
     gnomad_pops_legend: list[str] = hl.read_table(
         str(table_pairs[0].sites_table_path)
     ).pops.collect()[0]
+    # All pairs must share the same pops legends so a single remap into the joint legend is valid
+    # for every contig; otherwise the exported gnomAD_AF_* columns would be misaligned.
+    for tp in table_pairs[1:]:
+        tp_hgdp_pops: list[str] = hl.read_table(str(tp.haplotype_table_path)).pops.collect()[0]
+        tp_gnomad_pops: list[str] = hl.read_table(str(tp.sites_table_path)).pops.collect()[0]
+        if tp_hgdp_pops != hgdp_pops_legend or tp_gnomad_pops != gnomad_pops_legend:
+            raise ValueError(
+                f"Pops legend mismatch for contig {tp.contig}: "
+                f"haplotype pops {tp_hgdp_pops} vs {hgdp_pops_legend}, "
+                f"sites pops {tp_gnomad_pops} vs {gnomad_pops_legend}."
+            )
     # Joint legend: gnomAD pops in their original order, then any HGDP-only pops appended.
     joint_pops_legend: list[str] = list(gnomad_pops_legend) + [
         p for p in hgdp_pops_legend if p not in gnomad_pops_legend

--- a/divref/divref/tools/remap_divref.py
+++ b/divref/divref/tools/remap_divref.py
@@ -190,6 +190,8 @@ def _intervals_overlap(start1: int, end1: int, start2: int, end2: int) -> bool:
     return start1 < end2 and start2 < end1
 
 
+# Missing-AF tokens seen in the TSVs exported by Hail/`create_duckdb_index`: "null" and "NA" come
+# from Hail's missing representation; the empty string appears when a pop has no entry at all.
 _MISSING_AF_TOKENS = frozenset({"null", "NA", ""})
 
 

--- a/divref/divref/tools/remap_divref.py
+++ b/divref/divref/tools/remap_divref.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 from pathlib import Path
+from typing import Any
 from typing import Optional
 
 import duckdb
@@ -15,6 +16,8 @@ from pydantic import Field
 from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
+
+_GNOMAD_AF_COLUMN_PREFIX = "gnomAD_AF_"
 
 
 class Variant(BaseModel):
@@ -73,13 +76,32 @@ class Haplotype(BaseModel):
     max_pop: str
     variants: str
     source: str
-    gnomad_af_afr: str = Field(alias="gnomAD_AF_afr")
-    gnomad_af_amr: str = Field(alias="gnomAD_AF_amr")
-    gnomad_af_eas: str = Field(alias="gnomAD_AF_eas")
-    gnomad_af_nfe: str = Field(alias="gnomAD_AF_nfe")
-    gnomad_af_sas: str = Field(alias="gnomAD_AF_sas")
+    # Per-pop comma-delimited gnomAD AF strings, keyed by pop label. The dict's iteration order
+    # is the order of `joint_pops_legend` used when constructing the index.
+    gnomad_afs: dict[str, str]
 
     _variants: Optional[list[Variant]] = None
+
+    @classmethod
+    def from_row(cls, row: dict[str, Any], pops_legend: list[str]) -> "Haplotype":
+        """
+        Build a Haplotype from a DuckDB `sequences` row, separating per-pop AF columns.
+
+        Args:
+            row: Mapping from DuckDB column name to value for one `sequences` row.
+            pops_legend: Ordered list of population labels expected as `gnomAD_AF_{pop}` columns.
+                The resulting `gnomad_afs` dict preserves this ordering.
+
+        Returns:
+            Haplotype instance with `gnomad_afs` populated from the per-pop columns.
+        """
+        gnomad_afs: dict[str, str] = {
+            pop: row[f"{_GNOMAD_AF_COLUMN_PREFIX}{pop}"] for pop in pops_legend
+        }
+        base: dict[str, Any] = {
+            k: v for k, v in row.items() if not k.startswith(_GNOMAD_AF_COLUMN_PREFIX)
+        }
+        return cls(**base, gnomad_afs=gnomad_afs)
 
     def parsed_variants(self) -> list[Variant]:
         """
@@ -146,13 +168,7 @@ class Haplotype(BaseModel):
         reference_coord_start = _translate_coordinate_to_ref(start, -1, vs, variant_intervals)
         reference_coord_end = _translate_coordinate_to_ref(end, 1, vs, variant_intervals)
 
-        all_pop_freqs = {
-            "afr": _parse_pop_freqs(self.gnomad_af_afr),
-            "amr": _parse_pop_freqs(self.gnomad_af_amr),
-            "eas": _parse_pop_freqs(self.gnomad_af_eas),
-            "nfe": _parse_pop_freqs(self.gnomad_af_nfe),
-            "sas": _parse_pop_freqs(self.gnomad_af_sas),
-        }
+        all_pop_freqs = {pop: _parse_pop_freqs(encoded) for pop, encoded in self.gnomad_afs.items()}
 
         if first_variant_index is not None and last_variant_index is not None:
             variants_involved = vs[first_variant_index : last_variant_index + 1]
@@ -174,8 +190,11 @@ def _intervals_overlap(start1: int, end1: int, start2: int, end2: int) -> bool:
     return start1 < end2 and start2 < end1
 
 
+_MISSING_AF_TOKENS = frozenset({"null", "NA", ""})
+
+
 def _parse_pop_freqs(encoded: str) -> list[float]:
-    return [0.0 if v == "null" else float(v) for v in encoded.split(",")]
+    return [0.0 if v in _MISSING_AF_TOKENS else float(v) for v in encoded.split(",")]
 
 
 def _translate_coordinate_to_ref(
@@ -238,7 +257,7 @@ def _get_index_connection(index_path: Optional[Path]) -> duckdb.DuckDBPyConnecti
     return duckdb.connect(str(index_path))
 
 
-def remap_divref(
+def remap_divref(  # noqa: C901
     *,
     input_path: Path,
     output_path: Path,
@@ -297,6 +316,13 @@ def remap_divref(
         )
     window_size: int = window_size_row[0]
 
+    joint_pops_legend_row = conn.execute("SELECT * FROM joint_pops_legend").fetchone()
+    if joint_pops_legend_row is None:
+        raise RuntimeError(
+            "Index is missing joint_pops_legend table — ensure this is a valid DivRef index."
+        )
+    joint_pops_legend: list[str] = json.loads(joint_pops_legend_row[0])
+
     contigs: list[str] = []
     starts: list[int] = []
     ends: list[int] = []
@@ -325,7 +351,7 @@ def remap_divref(
         columns = [desc[0] for desc in conn.description]
         id_to_hap: dict[str, Haplotype] = {}
         for row in results:
-            hap = Haplotype(**dict(zip(columns, row, strict=True)))
+            hap = Haplotype.from_row(dict(zip(columns, row, strict=True)), joint_pops_legend)
             id_to_hap[hap.sequence_id] = hap
 
         for _, df_row in batch_df.iterrows():

--- a/divref/tests/tools/test_remap_divref.py
+++ b/divref/tests/tools/test_remap_divref.py
@@ -9,6 +9,14 @@ from divref.tools.remap_divref import ReferenceMapping
 from divref.tools.remap_divref import Variant
 from divref.tools.remap_divref import _parse_pop_freqs
 
+_DEFAULT_GNOMAD_AFS: dict[str, str] = {
+    "afr": "0.1,0.2,0.3",
+    "amr": "0.15,0.25,0.35",
+    "eas": "0.12,0.22,0.32",
+    "nfe": "0.11,0.21,0.31",
+    "sas": "0.13,0.23,0.33",
+}
+
 
 def create_haplotype(
     sequence_id: str = "test_hap",
@@ -16,11 +24,7 @@ def create_haplotype(
     sequence_length: int = 4,
     n_variants: int = 3,
     variants: str = "1:500:A:T,1:505:C:G,1:510:T:A",
-    gnomAD_AF_afr: str = "0.1,0.2,0.3",  # noqa: N803
-    gnomAD_AF_amr: str = "0.15,0.25,0.35",  # noqa: N803
-    gnomAD_AF_eas: str = "0.12,0.22,0.32",  # noqa: N803
-    gnomAD_AF_nfe: str = "0.11,0.21,0.31",  # noqa: N803
-    gnomAD_AF_sas: str = "0.13,0.23,0.33",  # noqa: N803
+    gnomad_afs: dict[str, str] | None = None,
     **kwargs: Any,
 ) -> Haplotype:
     """
@@ -32,11 +36,8 @@ def create_haplotype(
         sequence_length: Length of the sequence.
         n_variants: Number of variants in the haplotype.
         variants: Comma-separated variant strings (chrom:pos:ref:alt).
-        gnomAD_AF_afr: Comma-separated AFR allele frequencies per variant.
-        gnomAD_AF_amr: Comma-separated AMR allele frequencies per variant.
-        gnomAD_AF_eas: Comma-separated EAS allele frequencies per variant.
-        gnomAD_AF_nfe: Comma-separated NFE allele frequencies per variant.
-        gnomAD_AF_sas: Comma-separated SAS allele frequencies per variant.
+        gnomad_afs: Mapping from pop label to comma-delimited per-variant AF string. Defaults to
+            a five-population (afr/amr/eas/nfe/sas) dict if not provided.
         **kwargs: Additional fields passed to Haplotype.
 
     Returns:
@@ -57,11 +58,7 @@ def create_haplotype(
         sequence_length=sequence_length,
         n_variants=n_variants,
         variants=variants,
-        gnomAD_AF_afr=gnomAD_AF_afr,
-        gnomAD_AF_amr=gnomAD_AF_amr,
-        gnomAD_AF_eas=gnomAD_AF_eas,
-        gnomAD_AF_nfe=gnomAD_AF_nfe,
-        gnomAD_AF_sas=gnomAD_AF_sas,
+        gnomad_afs=dict(_DEFAULT_GNOMAD_AFS) if gnomad_afs is None else gnomad_afs,
         **defaults,
     )
 
@@ -127,11 +124,13 @@ def test_complex_multi_indel_mapping() -> None:
     haplotype = create_haplotype(
         sequence_id="hap5",
         variants="1:500:AT:A,1:505:C:CTT,1:510:GGG:T",
-        gnomAD_AF_afr="0.05,0.15,0.25",
-        gnomAD_AF_amr="0.06,0.16,0.26",
-        gnomAD_AF_eas="0.07,0.17,0.27",
-        gnomAD_AF_nfe="0.04,0.14,0.24",
-        gnomAD_AF_sas="0.03,0.13,0.23",
+        gnomad_afs={
+            "afr": "0.05,0.15,0.25",
+            "amr": "0.06,0.16,0.26",
+            "eas": "0.07,0.17,0.27",
+            "nfe": "0.04,0.14,0.24",
+            "sas": "0.03,0.13,0.23",
+        },
     )
     rm = haplotype.reference_mapping(9, 22, 10)
 
@@ -153,11 +152,13 @@ def test_large_insertion_with_null_frequencies() -> None:
         sequence_length=42,
         n_variants=1,
         variants=f"chr12:90349349:T:{alt}",
-        gnomAD_AF_afr="null",
-        gnomAD_AF_amr="null",
-        gnomAD_AF_eas="null",
-        gnomAD_AF_nfe="null",
-        gnomAD_AF_sas="null",
+        gnomad_afs={
+            "afr": "null",
+            "amr": "null",
+            "eas": "null",
+            "nfe": "null",
+            "sas": "null",
+        },
     )
     rm = haplotype.reference_mapping(22, 42, 25)
 
@@ -305,6 +306,35 @@ def test_parse_pop_freqs_nulls_become_zero() -> None:
 def test_parse_pop_freqs_single_null() -> None:
     """_parse_pop_freqs should return [0.0] for a single 'null' entry."""
     assert _parse_pop_freqs("null") == [0.0]
+
+
+def test_parse_pop_freqs_na_treated_as_missing() -> None:
+    """'NA' (Hail's default TSV missing token) should parse to 0.0 alongside 'null'."""
+    assert _parse_pop_freqs("0.1,NA,null,0.4") == [0.1, 0.0, 0.0, 0.4]
+
+
+def test_from_row_splits_per_pop_columns() -> None:
+    """Haplotype.from_row should pull gnomAD_AF_* columns into gnomad_afs by pop label."""
+    pops_legend = ["afr", "amr", "eas"]
+    row: dict[str, Any] = {
+        "sequence_id": "row_hap",
+        "sequence": "ACGT",
+        "sequence_length": 4,
+        "n_variants": 1,
+        "fraction_phased": 1.0,
+        "popmax_empirical_AF": 0.5,
+        "popmax_empirical_AC": 10,
+        "estimated_gnomad_AF": 0.5,
+        "max_pop": "afr",
+        "variants": "chr1:100:A:T",
+        "source": "test",
+        "gnomAD_AF_afr": "0.5",
+        "gnomAD_AF_amr": "0.3",
+        "gnomAD_AF_eas": "NA",
+    }
+    hap = Haplotype.from_row(row, pops_legend)
+    assert hap.gnomad_afs == {"afr": "0.5", "amr": "0.3", "eas": "NA"}
+    assert list(hap.gnomad_afs.keys()) == pops_legend
 
 
 # ---------------------------------------------------------------------------

--- a/workflows/config/config_schema.yml
+++ b/workflows/config/config_schema.yml
@@ -37,13 +37,13 @@ properties:
     description: List of chromosomes to generate the resource for.
     default: ["chr1", "chr2", "chr3", "chr4", "chr5", "chr6", "chr7", "chr8", "chr9", "chr10", "chr11", "chr12", "chr13", "chr14", "chr15", "chr16", "chr17", "chr18", "chr19", "chr20", "chr21", "chr22", "chrX", "chrY"]
 
-  populations:
+  hgdp_1kg_populations:
     type: array
     items:
       type: string
     minItems: 1
     uniqueItems: true
-    description: List of populations to use.
+    description: List of populations to use when generating haplotypes from HGDP+1KG data.
     default: ["afr", "amr", "eas", "sas", "nfe"]
 
   hgdp_1kg_phased_bcf_prefix:
@@ -124,6 +124,15 @@ properties:
       Minimum variant allele frequency for at least one selected population when running
       `divref extract-gnomad-single-afs`.
     default: 0.005
+
+  gnomad_variant_populations:
+    type: array
+    items:
+      type: string
+    minItems: 1
+    uniqueItems: true
+    description: List of populations to use when selecting single variants from gnomAD data.
+    default: ["afr", "amr", "eas", "sas", "nfe"]
 
   sequence_window_size:
     type: integer

--- a/workflows/generate_divref.smk
+++ b/workflows/generate_divref.smk
@@ -52,7 +52,6 @@ WORK_DIR: Path = Path(config["work_dir"])
 TMP_DIR: Path = Path(config["tmp_dir"])
 
 CHROMS: list[str] = config["chromosomes"]
-POPS: list[str] = config["populations"]
 
 REFERENCE_GENOME: str = config["reference_genome_base_name"]
 REFERENCE_GENOME_URI: str = config["reference_genome_uri"]
@@ -63,6 +62,7 @@ HGDP_1KG_PHASED_BCF_PREFIX: str = config["hgdp_1kg_phased_bcf_prefix"]
 HGDP_1KG_PHASED_BCF_SUFFIX: str = config["hgdp_1kg_phased_bcf_suffix"]
 HGDP_1KG_VARIANT_ANNOTATION_HAIL_TABLE: str = config["hgdp_1kg_variant_annotation_hail_table"]
 HGDP_1KG_SAMPLE_METADATA_HAIL_TABLE: str = config["hgdp_1kg_sample_metadata_hail_table"]
+HGDP_1KG_POPS: list[str] = config["hgdp_1kg_populations"]
 HGDP_1KG_MIN_POP_VARIANT_AF: float = config["hgdp_1kg_min_pop_variant_allele_freq"]
 HGDP_1KG_MIN_POP_HAPLOTYPE_AF: float = config["hgdp_1kg_min_estimated_gnomad_haplotype_allele_freq"]
 HGDP_1KG_HAPLOTYPE_WINDOW_SIZE: int = config["hgdp_1kg_haplotype_window_size"]
@@ -71,6 +71,7 @@ HGDP_1KG_HAPLOTYPE_WINDOW_SIZE: int = config["hgdp_1kg_haplotype_window_size"]
 # derived from the workflow-level `cloud` so all inputs come from the same provider.
 GNOMAD_VARIANT_ANNOTATION_SOURCE: str = config["gnomad_variant_annotation_source"]
 GNOMAD_VARIANT_ANNOTATION_CLOUD: str = _GNOMAD_CLOUD_FOR[CLOUD]
+GNOMAD_VARIANT_POPS: list[str] = config["gnomad_variant_populations"]
 GNOMAD_VARIANT_MIN_POP_VARIANT_AF: float = config["gnomad_variant_min_pop_variant_allele_freq"]
 
 SEQUENCE_WINDOW_SIZE: int = config["sequence_window_size"]
@@ -141,7 +142,7 @@ rule extract_gnomad_afs:
     params:
         variant_ht=HGDP_1KG_VARIANT_ANNOTATION_HAIL_TABLE,
         freq_threshold=HGDP_1KG_MIN_POP_VARIANT_AF,
-        populations=" ".join(POPS),
+        populations=" ".join(HGDP_1KG_POPS),
         spark_driver_memory_gb=SPARK_DRIVER_MEMORY_GB,
         spark_executor_memory_gb=SPARK_EXECUTOR_MEMORY_GB,
         use_s3_flag="--use-s3" if CLOUD == "AWS" else "--no-use-s3",
@@ -242,7 +243,7 @@ rule extract_gnomad_variant_afs:
         gnomad_source=GNOMAD_VARIANT_ANNOTATION_SOURCE,
         gnomad_cloud=GNOMAD_VARIANT_ANNOTATION_CLOUD,
         freq_threshold=GNOMAD_VARIANT_MIN_POP_VARIANT_AF,
-        populations=" ".join(POPS),
+        populations=" ".join(GNOMAD_VARIANT_POPS),
         spark_driver_memory_gb=SPARK_DRIVER_MEMORY_GB,
         spark_executor_memory_gb=SPARK_EXECUTOR_MEMORY_GB,
         gcs_credentials_flag=GCS_CREDENTIALS_FLAG,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Split population configuration into separate `hgdp_1kg_populations` and `gnomad_variant_populations` parameters for more granular control over population selections in extraction workflows.

* **Chores**
  * Added samtools dependency (≥1.23.1, <2).

* **Refactor**
  * Enhanced internal haplotype population frequency handling to support dynamic population legends.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/divref-wf/pull/52)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->