### PR TITLE
feat: empirical allele frequency calculation per population

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ The primary table in the DuckDB index is the `sequences` table, which has one ro
 | `popmax_fraction_phased` | For `HGDP_haplotype`: phase ratio, `popmax_empirical_AF / min(empirical_AF[component, max_pop])` — empirical haplotype AF over empirical AF of the rarest component variant in the same population. `1.0` for `gnomAD_variant`. Equivalent to `fraction_phased_{max_pop}`. |
 | `variants` | Comma-separated list of component variants in `chr:pos:ref:alt` form, in the order they appear in the haplotype. |
 | `gnomAD_AF_{POP}` | One column per configured population (e.g. `gnomAD_AF_AFR`). Comma-separated per-component gnomAD AFs in that population, in the same order as `variants`, formatted to 5 decimal places. |
-| `empirical_AC_{POP}` | One column per pop in `joint_pops_legend`. Scalar allele count in that pop. Missing if the pop has no source data for this row. |
-| `empirical_AF_{POP}` | Scalar empirical AF in that pop, derived from `empirical_AC_{POP}` and the min AN over component variants. Missing if AN is 0 or the pop has no source data. |
+| `empirical_AC_{POP}` | One column per pop in `joint_pops_legend`. For `HGDP_haplotype`: count of chromosomes carrying the haplotype in that pop (haplotype-level). For `gnomAD_variant`: the gnomAD AC for that variant in that pop (variant-level). Missing if the pop has no source data for this row. |
+| `empirical_AF_{POP}` | For `HGDP_haplotype`: empirical AF of the haplotype in that pop, derived from `empirical_AC_{POP}` and the min AN over component variants. For `gnomAD_variant`: the gnomAD AF for that variant in that pop. Missing if AN is 0 or the pop has no source data. |
 | `fraction_phased_{POP}` | Per-pop phase ratio: `empirical_AF_{POP} / min(local_call_stats_AF[component, POP])`. `1.0` for `gnomAD_variant` rows. Uses *that pop's own* denominators (not `max_pop`'s). |
 | `estimated_gnomad_AF_{POP}` | Per-pop projection: `fraction_phased_{POP} × min(gnomAD_AF[component, POP])`. Equals `empirical_AF_{POP}` for `gnomAD_variant` rows. |
 

--- a/README.md
+++ b/README.md
@@ -134,11 +134,14 @@ The primary table in the DuckDB index is the `sequences` table, which has one ro
 | `max_pop` | Population code with the highest empirical AF for this haplotype/variant. |
 | `popmax_empirical_AF` | For `HGDP_haplotype`: empirical AF of the haplotype in `max_pop` from observed phased genotypes. For `gnomAD_variant`: the gnomAD AF in `max_pop`. |
 | `popmax_empirical_AC` | Allele count corresponding to `popmax_empirical_AF`. |
-| `estimated_gnomad_AF` | For `HGDP_haplotype`: `fraction_phased x min(gnomAD_AF[component, max_pop])` over the component variants — i.e. the phase ratio applied to the rarest component's gnomAD AF in `max_pop`. For `gnomAD_variant`: the gnomAD AF in `max_pop`. |
-| `fraction_phased` | For `HGDP_haplotype`: phase ratio, `popmax_empirical_AF / min(empirical_AF[component, max_pop])` — empirical haplotype AF over empirical AF of the rarest component variant in the same population. `1.0` for `gnomAD_variant`. |
-| `all_pop_freqs` | Array of structs (one per joint pop legend entry) with fields `pop` (int — index into `pops_legend`), `empirical_AC`, `empirical_AF`, `fraction_phased`, and `estimated_gnomad_AF`. Each entry holds the same metric definitions as the scalar `popmax_*` / `fraction_phased` / `estimated_gnomad_AF` columns but computed using *that pop's own* denominators (not `max_pop`'s). Sorted by `empirical_AF` descending; missing AFs sort to the end. For `gnomAD_variant`: `fraction_phased=1.0` and `estimated_gnomad_AF=empirical_AF` for every pop. |
+| `popmax_estimated_gnomad_AF` | For `HGDP_haplotype`: `popmax_fraction_phased × min(gnomAD_AF[component, max_pop])` over the component variants — i.e. the phase ratio applied to the rarest component's gnomAD AF in `max_pop`. For `gnomAD_variant`: the gnomAD AF in `max_pop`. Equivalent to `estimated_gnomad_AF_{max_pop}`. |
+| `popmax_fraction_phased` | For `HGDP_haplotype`: phase ratio, `popmax_empirical_AF / min(empirical_AF[component, max_pop])` — empirical haplotype AF over empirical AF of the rarest component variant in the same population. `1.0` for `gnomAD_variant`. Equivalent to `fraction_phased_{max_pop}`. |
 | `variants` | Comma-separated list of component variants in `chr:pos:ref:alt` form, in the order they appear in the haplotype. |
 | `gnomAD_AF_{POP}` | One column per configured population (e.g. `gnomAD_AF_AFR`). Comma-separated per-component gnomAD AFs in that population, in the same order as `variants`, formatted to 5 decimal places. |
+| `empirical_AC_{POP}` | One column per pop in `joint_pops_legend`. Scalar allele count in that pop. Missing if the pop has no source data for this row. |
+| `empirical_AF_{POP}` | Scalar empirical AF in that pop, derived from `empirical_AC_{POP}` and the min AN over component variants. Missing if AN is 0 or the pop has no source data. |
+| `fraction_phased_{POP}` | Per-pop phase ratio: `empirical_AF_{POP} / min(local_call_stats_AF[component, POP])`. `1.0` for `gnomAD_variant` rows. Uses *that pop's own* denominators (not `max_pop`'s). |
+| `estimated_gnomad_AF_{POP}` | Per-pop projection: `fraction_phased_{POP} × min(gnomAD_AF[component, POP])`. Equals `empirical_AF_{POP}` for `gnomAD_variant` rows. |
 
 The DuckDB file also contains three single-row metadata tables: `window_size` (the flanking context size used), `pops_legend` (JSON-encoded ordered population list), and `VERSION`.
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Each pass independently:
 - If the same haplotype appears in both passes (e.g., a block fully contained in one bin of pass 1 and also one bin of pass 2), it is *kept twice* — one row per pass — unless a later `distinct()` collapses them. This is one source of double-counting.
 
 **Stage 5: per-fragment metrics**
-- Same as new: derive `max_pop`, `max_empirical_AF`, `max_empirical_AC`, `min_variant_frequency`, `fraction_phased`, `estimated_gnomad_AF`.
+- Same as new: derive `max_pop`, `max_empirical_AF`, `max_empirical_AC`, `min_variant_frequency`, `fraction_phased`, `estimated_gnomad_AF`. **Note:** in the old algorithm `min_variant_frequency` was derived from the gnomAD-sites AF rather than the local HGDP+1KG `call_stats.AF[1]`; with the gnomAD AF on both sides of the formula the gnomAD multiplier cancels and `estimated_gnomad_AF` collapses to `max_empirical_AF`. This was corrected as part of the rewrite — the column definitions in the table above describe the new (correct) semantic.
 
 **Stage 6: filter**
 - `min_variant_frequency > 0` and `estimated_gnomad_AF >= haplotype_freq_threshold`.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The primary table in the DuckDB index is the `sequences` table, which has one ro
 | `popmax_empirical_AC` | Allele count corresponding to `popmax_empirical_AF`. |
 | `estimated_gnomad_AF` | For `HGDP_haplotype`: `fraction_phased x min(gnomAD_AF[component, max_pop])` over the component variants — i.e. the phase ratio applied to the rarest component's gnomAD AF in `max_pop`. For `gnomAD_variant`: the gnomAD AF in `max_pop`. |
 | `fraction_phased` | For `HGDP_haplotype`: phase ratio, `popmax_empirical_AF / min(empirical_AF[component, max_pop])` — empirical haplotype AF over empirical AF of the rarest component variant in the same population. `1.0` for `gnomAD_variant`. |
+| `all_pop_freqs` | Array of structs (one per joint pop legend entry) with fields `pop` (int — index into `pops_legend`), `empirical_AC`, `empirical_AF`, `fraction_phased`, and `estimated_gnomad_AF`. Each entry holds the same metric definitions as the scalar `popmax_*` / `fraction_phased` / `estimated_gnomad_AF` columns but computed using *that pop's own* denominators (not `max_pop`'s). Sorted by `empirical_AF` descending; missing AFs sort to the end. For `gnomAD_variant`: `fraction_phased=1.0` and `estimated_gnomad_AF=empirical_AF` for every pop. |
 | `variants` | Comma-separated list of component variants in `chr:pos:ref:alt` form, in the order they appear in the haplotype. |
 | `gnomAD_AF_{POP}` | One column per configured population (e.g. `gnomAD_AF_AFR`). Comma-separated per-component gnomAD AFs in that population, in the same order as `variants`, formatted to 5 decimal places. |
 

--- a/divref/divref/tools/compute_haplotypes.py
+++ b/divref/divref/tools/compute_haplotypes.py
@@ -260,11 +260,21 @@ def _compute_metrics(hap_table: hl.Table, n_pops: int) -> hl.Table:
             - `max_pop` (int)
             - `max_empirical_AF` (float64)
             - `max_empirical_AC` (int)
-            - `min_variant_frequency` (float64): min gnomAD AF over segment variants for `max_pop`.
-            - `all_pop_freqs` (array<struct(pop, empirical_AC, empirical_AF)>): sorted by AF desc.
+            - `min_variant_frequency` (float64): min over component variants of the *local*
+              HGDP+1KG `call_stats` alt AF in `max_pop` — the rarest haplotype-component
+              variant's frequency in the population where the haplotype is most common.
+            - `all_pop_freqs` (array<struct(pop, empirical_AC, empirical_AF, fraction_phased,
+              estimated_gnomad_AF)>): per-population view of all three frequency-derived
+              metrics, sorted by `empirical_AF` descending. `pop` indexes into the table's
+              `globals.pops` legend.
             - `fraction_phased` (float64): `max_empirical_AF / min_variant_frequency`.
+              The proportion of chromosomes carrying the rarest component variant in
+              `max_pop` (in HGDP+1KG) that also carry the full haplotype.
             - `estimated_gnomad_AF` (float64): min over segment variants of
-              `gnomad_freqs[i][max_pop].AF * fraction_phased`.
+              `gnomad_freqs[i][max_pop].AF * fraction_phased`. The haplotype's projected
+              frequency in `max_pop` of the broader gnomAD population, extrapolated from
+              the HGDP+1KG LD pattern. Equivalent to `all_pop_freqs[max_pop]
+              .estimated_gnomad_AF`.
     """
     pops_range = hl.range(0, n_pops)
     hap_table = hap_table.annotate(
@@ -281,36 +291,77 @@ def _compute_metrics(hap_table: hl.Table, n_pops: int) -> hl.Table:
                     )
                 ),
             )
-        )
+        ),
+        # Per-population min over component variants of the *local* HGDP+1KG `call_stats` alt
+        # AF — the rarest haplotype-component variant's frequency in that pop, measured in
+        # the BCF we just processed (not the broader gnomAD sites table). Used as the
+        # denominator of `fraction_phased`, which then scales gnomAD per-variant AFs into
+        # per-haplotype frequency estimates. Using the local AF (rather than the gnomAD
+        # sites AF) is essential: with gnomAD AFs on both sides of the formula the gnomAD
+        # multiplier cancels and `estimated_gnomad_AF` collapses to `max_empirical_AF`.
+        _min_local_variant_AF_by_pop=pops_range.map(
+            lambda p: hl.min(
+                hap_table.frequencies_by_pop.map(
+                    lambda fbp: fbp.get(p, hl.missing(fbp.dtype.value_type)).AF[1]
+                )
+            )
+        ),
+    )
+    # Per-pop fraction_phased and estimated_gnomad_AF, computed up front so we can bundle
+    # all three frequency-derived metrics into `all_pop_freqs` and then pick out the scalar
+    # values at `max_pop` for backward compatibility.
+    hap_table = hap_table.annotate(
+        _per_pop_fraction_phased=pops_range.map(
+            lambda p: hl.bind(
+                lambda emp_af, min_var_af: hl.if_else(
+                    hl.is_defined(emp_af) & hl.is_defined(min_var_af) & (min_var_af > 0),
+                    emp_af / min_var_af,
+                    hl.missing(hl.tfloat64),
+                ),
+                hap_table._per_pop_AF[p],
+                hap_table._min_local_variant_AF_by_pop[p],
+            )
+        ),
+    )
+    hap_table = hap_table.annotate(
+        _per_pop_estimated_gnomad_AF=pops_range.map(
+            lambda p: hl.bind(
+                lambda fp: hl.if_else(
+                    hl.is_defined(fp),
+                    hl.min(hap_table.gnomad_freqs.map(lambda x: x[p].AF * fp)),
+                    hl.missing(hl.tfloat64),
+                ),
+                hap_table._per_pop_fraction_phased[p],
+            )
+        ),
     )
     hap_table = hap_table.annotate(max_pop=hl.argmax(hap_table._per_pop_AF))
     hap_table = hap_table.annotate(
         max_empirical_AF=hap_table._per_pop_AF[hap_table.max_pop],
         max_empirical_AC=hap_table.per_pop_AC[hap_table.max_pop],
-        min_variant_frequency=hl.min(hap_table.gnomad_freqs.map(lambda x: x[hap_table.max_pop].AF)),
+        min_variant_frequency=hap_table._min_local_variant_AF_by_pop[hap_table.max_pop],
+        fraction_phased=hap_table._per_pop_fraction_phased[hap_table.max_pop],
+        estimated_gnomad_AF=hap_table._per_pop_estimated_gnomad_AF[hap_table.max_pop],
         all_pop_freqs=hl.sorted(
             pops_range.map(
                 lambda p: hl.struct(
                     pop=p,
                     empirical_AC=hap_table.per_pop_AC[p],
                     empirical_AF=hap_table._per_pop_AF[p],
+                    fraction_phased=hap_table._per_pop_fraction_phased[p],
+                    estimated_gnomad_AF=hap_table._per_pop_estimated_gnomad_AF[p],
                 )
             ),
             key=lambda s: s.empirical_AF,
             reverse=True,
         ),
     )
-    hap_table = hap_table.annotate(
-        fraction_phased=hap_table.max_empirical_AF / hap_table.min_variant_frequency,
+    return hap_table.drop(
+        "_per_pop_AF",
+        "_min_local_variant_AF_by_pop",
+        "_per_pop_fraction_phased",
+        "_per_pop_estimated_gnomad_AF",
     )
-    hap_table = hap_table.annotate(
-        estimated_gnomad_AF=hl.min(
-            hap_table.gnomad_freqs.map(
-                lambda x: x[hap_table.max_pop].AF * hap_table.fraction_phased
-            )
-        ),
-    )
-    return hap_table.drop("_per_pop_AF")
 
 
 def _is_contiguous_subarray(short: tuple[int, ...], long_: tuple[int, ...]) -> bool:

--- a/divref/divref/tools/compute_haplotypes.py
+++ b/divref/divref/tools/compute_haplotypes.py
@@ -271,16 +271,18 @@ def _compute_metrics(hap_table: hl.Table, n_pops: int) -> hl.Table:
               `call_stats.AF[1]` — not `max_pop`'s. So
               `all_pop_freqs[p].fraction_phased = empirical_AF_p / min_local_AF_in_p` and
               `all_pop_freqs[p].estimated_gnomad_AF = min_i(gnomad_freqs[i][p].AF) *
-              all_pop_freqs[p].fraction_phased`. The scalar fields below are equivalent to
-              `all_pop_freqs[max_pop].*`.
+              all_pop_freqs[p].fraction_phased`. The scalar fields below correspond to the
+              entry whose `pop == max_pop` (note `all_pop_freqs` is sorted by `empirical_AF`,
+              not pop-indexed, so `all_pop_freqs[max_pop]` would be a positional access — not
+              the desired entry).
             - `fraction_phased` (float64): `max_empirical_AF / min_variant_frequency`.
               The proportion of chromosomes carrying the rarest component variant in
               `max_pop` (in HGDP+1KG) that also carry the full haplotype.
             - `estimated_gnomad_AF` (float64): min over segment variants of
               `gnomad_freqs[i][max_pop].AF * fraction_phased`. The haplotype's projected
               frequency in `max_pop` of the broader gnomAD population, extrapolated from
-              the HGDP+1KG LD pattern. Equivalent to `all_pop_freqs[max_pop]
-              .estimated_gnomad_AF`.
+              the HGDP+1KG LD pattern. Equivalent to the `estimated_gnomad_AF` value in the
+              `all_pop_freqs` entry whose `pop == max_pop`.
     """
     pops_range = hl.range(0, n_pops)
     hap_table = hap_table.annotate(

--- a/divref/divref/tools/compute_haplotypes.py
+++ b/divref/divref/tools/compute_haplotypes.py
@@ -266,7 +266,13 @@ def _compute_metrics(hap_table: hl.Table, n_pops: int) -> hl.Table:
             - `all_pop_freqs` (array<struct(pop, empirical_AC, empirical_AF, fraction_phased,
               estimated_gnomad_AF)>): per-population view of all three frequency-derived
               metrics, sorted by `empirical_AF` descending. `pop` indexes into the table's
-              `globals.pops` legend.
+              `globals.pops` legend. Each entry's `fraction_phased` and `estimated_gnomad_AF`
+              are computed using *that pop's own* `empirical_AF` and local
+              `call_stats.AF[1]` — not `max_pop`'s. So
+              `all_pop_freqs[p].fraction_phased = empirical_AF_p / min_local_AF_in_p` and
+              `all_pop_freqs[p].estimated_gnomad_AF = min_i(gnomad_freqs[i][p].AF) *
+              all_pop_freqs[p].fraction_phased`. The scalar fields below are equivalent to
+              `all_pop_freqs[max_pop].*`.
             - `fraction_phased` (float64): `max_empirical_AF / min_variant_frequency`.
               The proportion of chromosomes carrying the rarest component variant in
               `max_pop` (in HGDP+1KG) that also carry the full haplotype.

--- a/divref/divref/tools/create_duckdb_index.py
+++ b/divref/divref/tools/create_duckdb_index.py
@@ -471,12 +471,37 @@ def export_sequences_table_to_tsv(
     construction time (with missing-padding for pops absent from a source), so a uniform
     positional lookup is safe regardless of which source the row came from.
 
+    Four further per-pop columns are emitted per joint legend entry: `empirical_AC_{pop}`,
+    `empirical_AF_{pop}`, `fraction_phased_{pop}`, `estimated_gnomad_AF_{pop}`. Values come from
+    `all_pop_freqs` by joint-pop-index dict lookup; pops absent from a row's source are emitted
+    as missing.
+
+    The scalar columns `popmax_fraction_phased` and `popmax_estimated_gnomad_AF` are renamed
+    from `fraction_phased` / `estimated_gnomad_AF` to make the max-pop semantic explicit
+    alongside `popmax_empirical_AF` / `popmax_empirical_AC`.
+
     Args:
         ht: Annotated haplotype/variant table with sequences and variant strings.
         out_file: Path for the output TSV file.
         joint_pops_legend: Ordered list of all population codes across both input sources; used to
             resolve `max_pop` integer indices to labels and to name `gnomAD_AF_{pop}` columns.
     """
+    # Per-joint-pop dict lookup over `all_pop_freqs`. After build_*_table_entries the entries'
+    # `pop` field is already in the joint legend index space; pops absent from this row's source
+    # have no entry, and `.get(i, missing_struct)` returns missing for those.
+    pop_freq_value_type = ht.all_pop_freqs.dtype.element_type
+    ht = ht.annotate(
+        _pop_lookup=hl.dict(ht.all_pop_freqs.map(lambda x: (x.pop, x))),
+    )
+    missing_pop_struct = hl.missing(pop_freq_value_type)
+    per_pop_columns: dict[str, hl.Expression] = {}
+    for i, pop in enumerate(joint_pops_legend):
+        entry = ht._pop_lookup.get(i, missing_pop_struct)
+        per_pop_columns[f"empirical_AC_{pop}"] = entry.empirical_AC
+        per_pop_columns[f"empirical_AF_{pop}"] = entry.empirical_AF
+        per_pop_columns[f"fraction_phased_{pop}"] = entry.fraction_phased
+        per_pop_columns[f"estimated_gnomad_AF_{pop}"] = entry.estimated_gnomad_AF
+
     ht.select(
         "sequence",
         "sequence_length",
@@ -487,9 +512,9 @@ def export_sequences_table_to_tsv(
         "end",
         "popmax_empirical_AF",
         "popmax_empirical_AC",
-        "estimated_gnomad_AF",
-        "fraction_phased",
         "source",
+        popmax_estimated_gnomad_AF=ht.estimated_gnomad_AF,
+        popmax_fraction_phased=ht.fraction_phased,
         max_pop=hl.literal(joint_pops_legend)[ht.max_pop],
         variants=hl.delimit(ht.variant_strs, ","),
         **{
@@ -498,6 +523,7 @@ def export_sequences_table_to_tsv(
             )
             for i, pop in enumerate(joint_pops_legend)
         },
+        **per_pop_columns,
     ).export(str(out_file))
 
 

--- a/divref/divref/tools/create_duckdb_index.py
+++ b/divref/divref/tools/create_duckdb_index.py
@@ -295,6 +295,8 @@ def build_hgdp_haplotype_table_entries(
                 pop=hgdp_remap[x.pop],
                 empirical_AC=x.empirical_AC,
                 empirical_AF=x.empirical_AF,
+                fraction_phased=x.fraction_phased,
+                estimated_gnomad_AF=x.estimated_gnomad_AF,
             )
         ),
         gnomad_freqs=ht.gnomad_freqs.map(
@@ -363,6 +365,12 @@ def build_gnomad_variant_table_entries(
                 pop=gnomad_remap[i],
                 empirical_AC=va.gnomad_freqs[i].AC,
                 empirical_AF=va.gnomad_freqs[i].AF,
+                # For single-variant rows, the haplotype is a single allele, so phasing is
+                # trivially complete and the "estimated" gnomAD AF is just the gnomAD AF in
+                # the pop — matching the scalar `fraction_phased=1.0` and
+                # `estimated_gnomad_AF=va.gnomad_freqs[argmax_pop].AF` convention above.
+                fraction_phased=1.0,
+                estimated_gnomad_AF=va.gnomad_freqs[i].AF,
             )
         ),
         source="gnomAD_variant",

--- a/divref/divref/tools/remap_divref.py
+++ b/divref/divref/tools/remap_divref.py
@@ -352,9 +352,14 @@ def remap_divref(  # noqa: C901
     popmax_empirical_af: list[float] = []
     popmax_empirical_ac: list[int] = []
     max_pop: list[str] = []
-    all_pop_freqs_json: list[str] = []
-    estimated_gnomad_af_per_pop_json: list[str] = []
     source: list[str] = []
+    # One column per pop in the joint legend. `gnomad_af_per_pop` holds the comma-delimited
+    # per-variant AF strings (matches DuckDB's `gnomAD_AF_{POP}` columns verbatim);
+    # `estimated_gnomad_af_per_pop` holds the per-pop scalar haplotype-level estimated AF.
+    gnomad_af_per_pop: dict[str, list[str]] = {pop: [] for pop in joint_pops_legend}
+    estimated_gnomad_af_per_pop: dict[str, list[Optional[float]]] = {
+        pop: [] for pop in joint_pops_legend
+    }
 
     for batch_start in tqdm(range(0, len(df), batch_size)):
         batch_end = min(batch_start + batch_size, len(df))
@@ -407,10 +412,9 @@ def remap_divref(  # noqa: C901
             popmax_empirical_ac.append(found_hap.popmax_empirical_ac)
             max_pop.append(found_hap.max_pop)
             source.append(found_hap.source)
-            all_pop_freqs_json.append(json.dumps(rm.population_frequencies).replace(" ", ""))
-            estimated_gnomad_af_per_pop_json.append(
-                json.dumps(found_hap.estimated_gnomad_af_per_pop).replace(" ", "")
-            )
+            for pop in joint_pops_legend:
+                gnomad_af_per_pop[pop].append(found_hap.gnomad_afs[pop])
+                estimated_gnomad_af_per_pop[pop].append(found_hap.estimated_gnomad_af_per_pop[pop])
 
     df["divref_sequence_id"] = df[chrom_field]
     df["divref_start"] = df[start_field]
@@ -426,8 +430,9 @@ def remap_divref(  # noqa: C901
     df["popmax_empirical_AC"] = popmax_empirical_ac
     df["max_pop"] = max_pop
     df["variant_source"] = source
-    df["population_frequencies_json"] = all_pop_freqs_json
-    df["estimated_gnomad_af_per_pop_json"] = estimated_gnomad_af_per_pop_json
+    for pop in joint_pops_legend:
+        df[f"{_GNOMAD_AF_COLUMN_PREFIX}{pop}"] = gnomad_af_per_pop[pop]
+        df[f"{_ESTIMATED_GNOMAD_AF_COLUMN_PREFIX}{pop}"] = estimated_gnomad_af_per_pop[pop]
 
     df.to_csv(output_path, sep=separator, index=False, quoting=csv.QUOTE_MINIMAL)
     logger.info("Wrote remapped output to %s", output_path)

--- a/divref/divref/tools/remap_divref.py
+++ b/divref/divref/tools/remap_divref.py
@@ -18,6 +18,7 @@ from tqdm import tqdm
 logger = logging.getLogger(__name__)
 
 _GNOMAD_AF_COLUMN_PREFIX = "gnomAD_AF_"
+_ESTIMATED_GNOMAD_AF_COLUMN_PREFIX = "estimated_gnomad_AF_"
 
 
 class Variant(BaseModel):
@@ -62,46 +63,63 @@ class ReferenceMapping(BaseModel):
 class Haplotype(BaseModel):
     """A DivRef haplotype sequence with metadata and population frequency information."""
 
-    # Field names use aliases to match DuckDB column names (which use mixedCase).
-    model_config = ConfigDict(populate_by_name=True)
+    # Field names use aliases to match DuckDB column names (which use mixedCase). Extra columns
+    # (e.g. the per-pop `empirical_AC_{POP}` family) are ignored: this model only declares the
+    # fields `remap_divref` actually reads.
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
 
     sequence_id: str
     sequence: str
     sequence_length: int
     n_variants: int
-    fraction_phased: float
+    popmax_fraction_phased: float
     popmax_empirical_af: float = Field(alias="popmax_empirical_AF")
     popmax_empirical_ac: int = Field(alias="popmax_empirical_AC")
-    estimated_gnomad_af: float = Field(alias="estimated_gnomad_AF")
+    popmax_estimated_gnomad_af: float = Field(alias="popmax_estimated_gnomad_AF")
     max_pop: str
     variants: str
     source: str
     # Per-pop comma-delimited gnomAD AF strings, keyed by pop label. The dict's iteration order
     # is the order of `joint_pops_legend` used when constructing the index.
     gnomad_afs: dict[str, str]
+    # Per-pop scalar estimated gnomAD AF for the whole haplotype, keyed by pop label. None for
+    # pops with no source data on this row. Iteration order matches `joint_pops_legend`.
+    estimated_gnomad_af_per_pop: dict[str, Optional[float]]
 
     _variants: Optional[list[Variant]] = None
 
     @classmethod
     def from_row(cls, row: dict[str, Any], pops_legend: list[str]) -> "Haplotype":
         """
-        Build a Haplotype from a DuckDB `sequences` row, separating per-pop AF columns.
+        Build a Haplotype from a DuckDB `sequences` row, separating per-pop columns.
 
         Args:
             row: Mapping from DuckDB column name to value for one `sequences` row.
-            pops_legend: Ordered list of population labels expected as `gnomAD_AF_{pop}` columns.
-                The resulting `gnomad_afs` dict preserves this ordering.
+            pops_legend: Ordered list of population labels expected as `gnomAD_AF_{pop}` and
+                `estimated_gnomad_AF_{pop}` columns. The resulting `gnomad_afs` and
+                `estimated_gnomad_af_per_pop` dicts preserve this ordering.
 
         Returns:
-            Haplotype instance with `gnomad_afs` populated from the per-pop columns.
+            Haplotype instance with `gnomad_afs` and `estimated_gnomad_af_per_pop` populated
+            from the per-pop columns.
         """
         gnomad_afs: dict[str, str] = {
             pop: row[f"{_GNOMAD_AF_COLUMN_PREFIX}{pop}"] for pop in pops_legend
         }
-        base: dict[str, Any] = {
-            k: v for k, v in row.items() if not k.startswith(_GNOMAD_AF_COLUMN_PREFIX)
+        estimated_gnomad_af_per_pop: dict[str, Optional[float]] = {
+            pop: row[f"{_ESTIMATED_GNOMAD_AF_COLUMN_PREFIX}{pop}"] for pop in pops_legend
         }
-        return cls(**base, gnomad_afs=gnomad_afs)
+        base: dict[str, Any] = {
+            k: v
+            for k, v in row.items()
+            if not k.startswith(_GNOMAD_AF_COLUMN_PREFIX)
+            and not k.startswith(_ESTIMATED_GNOMAD_AF_COLUMN_PREFIX)
+        }
+        return cls(
+            **base,
+            gnomad_afs=gnomad_afs,
+            estimated_gnomad_af_per_pop=estimated_gnomad_af_per_pop,
+        )
 
     def parsed_variants(self) -> list[Variant]:
         """
@@ -335,6 +353,7 @@ def remap_divref(  # noqa: C901
     popmax_empirical_ac: list[int] = []
     max_pop: list[str] = []
     all_pop_freqs_json: list[str] = []
+    estimated_gnomad_af_per_pop_json: list[str] = []
     source: list[str] = []
 
     for batch_start in tqdm(range(0, len(df), batch_size)):
@@ -389,6 +408,9 @@ def remap_divref(  # noqa: C901
             max_pop.append(found_hap.max_pop)
             source.append(found_hap.source)
             all_pop_freqs_json.append(json.dumps(rm.population_frequencies).replace(" ", ""))
+            estimated_gnomad_af_per_pop_json.append(
+                json.dumps(found_hap.estimated_gnomad_af_per_pop).replace(" ", "")
+            )
 
     df["divref_sequence_id"] = df[chrom_field]
     df["divref_start"] = df[start_field]
@@ -405,6 +427,7 @@ def remap_divref(  # noqa: C901
     df["max_pop"] = max_pop
     df["variant_source"] = source
     df["population_frequencies_json"] = all_pop_freqs_json
+    df["estimated_gnomad_af_per_pop_json"] = estimated_gnomad_af_per_pop_json
 
     df.to_csv(output_path, sep=separator, index=False, quoting=csv.QUOTE_MINIMAL)
     logger.info("Wrote remapped output to %s", output_path)

--- a/divref/pyproject.toml
+++ b/divref/pyproject.toml
@@ -125,8 +125,9 @@ minversion = "7.4"
 addopts    = [
     "--color=yes",
     "--import-mode=importlib",
-    "--cov"
+    "--cov=divref",
 ]
+testpaths = ["tests"]
 
 [tool.coverage.run]
 omit = ["tests/*"]

--- a/divref/tests/tools/test_compute_haplotypes.py
+++ b/divref/tests/tools/test_compute_haplotypes.py
@@ -586,7 +586,9 @@ class MetricsRow:
     variant_pop_af: list[list[float]]
     # One inner dict per variant, mapping pop_int -> (AN, local_alt_AF). Local AF is the
     # HGDP+1KG `call_stats` alt-allele frequency and feeds `min_variant_frequency` /
-    # `fraction_phased`. Missing entries default to AN=0 and local_alt_AF=0.0.
+    # `fraction_phased`. A pop key absent from the dict for a given variant becomes
+    # `hl.missing` in `frequencies_by_pop` — the production code's `dict.get(p, missing)`
+    # path. To exercise AN=0 explicitly, supply `(0, 0.0)`.
     variant_pop_fbp: list[dict[int, tuple[int, float]]]
 
 
@@ -702,6 +704,40 @@ def test_compute_metrics_zero_an_yields_missing(hail_context: None) -> None:  # 
     assert rows[0].all_pop_freqs[0].empirical_AF == pytest.approx(0.1)
     assert rows[0].all_pop_freqs[1].pop == 0
     assert rows[0].all_pop_freqs[1].empirical_AF is None
+
+
+def test_compute_metrics_absent_pop_key_skips_variant_in_min(
+    hail_context: None,  # noqa: ARG001
+) -> None:
+    """A variant lacking a pop entry is silently skipped in that pop's per-variant min."""
+    # `hl.min` over a Hail array drops missing elements (NumPy-`nanmin` semantics), so a
+    # `dict.get(p, missing)` lookup at a variant where pop `p` is absent doesn't make the
+    # whole-haplotype metric missing — the min is taken over the surviving variants.
+    # Variant 0: both pops present. Variant 1: only pop 1.
+    # → `_per_pop_AF[0]` uses min(AN=100, missing) = 100 → empirical_AF[0] = 2/100 = 0.02.
+    # → `_min_local_variant_AF_by_pop[0]` = min(0.05, missing) = 0.05.
+    # → fraction_phased[0] = 0.02 / 0.05 = 0.4.
+    # → estimated_gnomad_AF[0] = min(0.5, 0.6) * 0.4 = 0.5 * 0.4 = 0.2.
+    ht = _make_metrics_input_ht([
+        MetricsRow(
+            haplotype=[0, 1],
+            per_pop_ac=[2, 4],
+            variant_pop_af=[[0.5, 0.4], [0.6, 0.3]],
+            variant_pop_fbp=[{0: (100, 0.05), 1: (200, 0.10)}, {1: (150, 0.08)}],
+        )
+    ])
+    rows = _compute_metrics(ht, n_pops=2).collect()
+    assert len(rows) == 1
+    row = rows[0]
+    # Pop 1 has higher AF (4/150 ≈ 0.027 vs 0.02 for pop 0). argmax picks pop 1.
+    assert row.max_pop == 1
+    pop_freqs_by_pop = {s.pop: s for s in row.all_pop_freqs}
+    # Pop 0: missing-at-variant-1 is silently skipped; metrics use only variant 0's pop-0 data.
+    assert pop_freqs_by_pop[0].empirical_AF == pytest.approx(0.02)
+    assert pop_freqs_by_pop[0].fraction_phased == pytest.approx(0.4)
+    assert pop_freqs_by_pop[0].estimated_gnomad_AF == pytest.approx(0.2)
+    # Pop 1 has data for both variants and is unaffected.
+    assert pop_freqs_by_pop[1].empirical_AF == pytest.approx(4 / 150)
 
 
 def test_compute_metrics_tie_breaks_to_smallest_index(

--- a/divref/tests/tools/test_compute_haplotypes.py
+++ b/divref/tests/tools/test_compute_haplotypes.py
@@ -683,6 +683,18 @@ def test_compute_metrics_picks_max_population(hail_context: None) -> None:  # no
     assert rows[0].max_empirical_AF == pytest.approx(0.05)
     # all_pop_freqs sorted by AF desc: pop 1 (0.05), pop 0 (0.01), pop 2 (0.0)
     assert [s.pop for s in rows[0].all_pop_freqs] == [1, 0, 2]
+    # Each entry's `fraction_phased` and `estimated_gnomad_AF` use that pop's own
+    # denominators — not max_pop's. Pin those values to lock in the per-pop semantics.
+    pop_freqs_by_pop = {s.pop: s for s in rows[0].all_pop_freqs}
+    # Pop 0: emp_AF = 2/200 = 0.01; min_local_AF = 0.04; fp = 0.25; est = 0.3 * 0.25 = 0.075.
+    assert pop_freqs_by_pop[0].fraction_phased == pytest.approx(0.01 / 0.04)
+    assert pop_freqs_by_pop[0].estimated_gnomad_AF == pytest.approx(0.3 * 0.01 / 0.04)
+    # Pop 1 (max): emp_AF = 5/100 = 0.05; min_local_AF = 0.10; fp = 0.5; est = 0.2 * 0.5 = 0.10.
+    assert pop_freqs_by_pop[1].fraction_phased == pytest.approx(0.05 / 0.10)
+    assert pop_freqs_by_pop[1].estimated_gnomad_AF == pytest.approx(0.2 * 0.05 / 0.10)
+    # Pop 2: emp_AF = 0/50 = 0.0; min_local_AF = 0.02; fp = 0.0; est = 0.0.
+    assert pop_freqs_by_pop[2].fraction_phased == pytest.approx(0.0)
+    assert pop_freqs_by_pop[2].estimated_gnomad_AF == pytest.approx(0.0)
 
 
 def test_compute_metrics_zero_an_yields_missing(hail_context: None) -> None:  # noqa: ARG001

--- a/divref/tests/tools/test_compute_haplotypes.py
+++ b/divref/tests/tools/test_compute_haplotypes.py
@@ -582,16 +582,20 @@ class MetricsRow:
 
     haplotype: list[int]
     per_pop_ac: list[int]
-    # One inner list per variant, each entry is the gnomAD AF for that variant in that pop.
+    # One inner list per variant, each entry is the gnomAD sites AF for that variant in that pop.
     variant_pop_af: list[list[float]]
-    # One inner dict per variant, mapping pop_int -> AN.
-    variant_pop_an: list[dict[int, int]]
+    # One inner dict per variant, mapping pop_int -> (AN, local_alt_AF). Local AF is the
+    # HGDP+1KG `call_stats` alt-allele frequency and feeds `min_variant_frequency` /
+    # `fraction_phased`. Missing entries default to AN=0 and local_alt_AF=0.0.
+    variant_pop_fbp: list[dict[int, tuple[int, float]]]
 
 
 def _make_metrics_input_ht(rows: list[MetricsRow]) -> hl.Table:
     """Construct a synthetic hap_table with the schema expected by `_compute_metrics`."""
     freq_type = hl.tstruct(AF=hl.tfloat64)
-    fbp_value_type = hl.tstruct(AN=hl.tint32)
+    # `frequencies_by_pop` mirrors the `hl.agg.call_stats` schema: AF is a per-allele array
+    # (index 0 = ref, index 1 = first alt). Only the alt entry is read.
+    fbp_value_type = hl.tstruct(AN=hl.tint32, AF=hl.tarray(hl.tfloat64))
     row_type = hl.tstruct(
         haplotype=hl.tarray(hl.tint64),
         per_pop_AC=hl.tarray(hl.tint64),
@@ -617,7 +621,8 @@ def _make_metrics_input_ht(rows: list[MetricsRow]) -> hl.Table:
             ],
             "gnomad_freqs": [[{"AF": af} for af in afs] for afs in r.variant_pop_af],
             "frequencies_by_pop": [
-                {p: {"AN": an} for p, an in ans.items()} for ans in r.variant_pop_an
+                {p: {"AN": an, "AF": [1.0 - alt_af, alt_af]} for p, (an, alt_af) in fbp.items()}
+                for fbp in r.variant_pop_fbp
             ],
         }
         for r in rows
@@ -631,8 +636,10 @@ def test_compute_metrics_single_population(hail_context: None) -> None:  # noqa:
         MetricsRow(
             haplotype=[0, 1],
             per_pop_ac=[3],
+            # gnomAD-sites AF per variant in pop 0.
             variant_pop_af=[[0.5], [0.4]],
-            variant_pop_an=[{0: 100}, {0: 200}],
+            # frequencies_by_pop: (AN, local_alt_AF) per variant in pop 0.
+            variant_pop_fbp=[{0: (100, 0.06)}, {0: (200, 0.05)}],
         )
     ])
     rows = _compute_metrics(ht, n_pops=1).collect()
@@ -642,11 +649,19 @@ def test_compute_metrics_single_population(hail_context: None) -> None:  # noqa:
     # min_AN over variants for pop 0 = min(100, 200) = 100. AF = 3/100 = 0.03.
     assert row.max_empirical_AF == pytest.approx(0.03)
     assert row.max_empirical_AC == 3
-    # min_variant_frequency = min(0.5, 0.4) = 0.4
-    assert row.min_variant_frequency == pytest.approx(0.4)
-    assert row.fraction_phased == pytest.approx(0.03 / 0.4)
-    # estimated_gnomad_AF = min(0.5 * fp, 0.4 * fp) = 0.4 * fp
-    assert row.estimated_gnomad_AF == pytest.approx(0.4 * 0.03 / 0.4)
+    # min_variant_frequency = min over variants of LOCAL alt AF in pop 0 = min(0.06, 0.05) = 0.05.
+    assert row.min_variant_frequency == pytest.approx(0.05)
+    assert row.fraction_phased == pytest.approx(0.03 / 0.05)
+    # estimated_gnomad_AF = min over variants of (gnomad_AF * fraction_phased)
+    #                    = min(0.5, 0.4) * 0.6 = 0.4 * 0.6 = 0.24.
+    assert row.estimated_gnomad_AF == pytest.approx(0.4 * 0.03 / 0.05)
+    # all_pop_freqs bundles all three per-pop quantities at pop 0.
+    assert len(row.all_pop_freqs) == 1
+    pop0 = row.all_pop_freqs[0]
+    assert pop0.pop == 0
+    assert pop0.empirical_AF == pytest.approx(0.03)
+    assert pop0.fraction_phased == pytest.approx(0.03 / 0.05)
+    assert pop0.estimated_gnomad_AF == pytest.approx(0.4 * 0.03 / 0.05)
 
 
 def test_compute_metrics_picks_max_population(hail_context: None) -> None:  # noqa: ARG001
@@ -657,7 +672,7 @@ def test_compute_metrics_picks_max_population(hail_context: None) -> None:  # no
             # pop 0: AC=2, AN=200 -> AF=0.01.  pop 1: AC=5, AN=100 -> AF=0.05.  pop 2: AC=0.
             per_pop_ac=[2, 5, 0],
             variant_pop_af=[[0.3, 0.2, 0.1]],
-            variant_pop_an=[{0: 200, 1: 100, 2: 50}],
+            variant_pop_fbp=[{0: (200, 0.04), 1: (100, 0.10), 2: (50, 0.02)}],
         )
     ])
     rows = _compute_metrics(ht, n_pops=3).collect()
@@ -676,7 +691,7 @@ def test_compute_metrics_zero_an_yields_missing(hail_context: None) -> None:  # 
             # pop 0: AC=1, AN=0 -> AF missing.  pop 1: AC=1, AN=10 -> AF=0.1.
             per_pop_ac=[1, 1],
             variant_pop_af=[[0.5, 0.4]],
-            variant_pop_an=[{0: 0, 1: 10}],
+            variant_pop_fbp=[{0: (0, 0.0), 1: (10, 0.20)}],
         )
     ])
     rows = _compute_metrics(ht, n_pops=2).collect()
@@ -698,7 +713,7 @@ def test_compute_metrics_tie_breaks_to_smallest_index(
             haplotype=[0],
             per_pop_ac=[1, 1],  # both AC=1 over AN=100 -> AF=0.01 each
             variant_pop_af=[[0.2, 0.2]],
-            variant_pop_an=[{0: 100, 1: 100}],
+            variant_pop_fbp=[{0: (100, 0.05), 1: (100, 0.05)}],
         )
     ])
     rows = _compute_metrics(ht, n_pops=2).collect()
@@ -823,10 +838,10 @@ def test_form_parent_blocks_multiple_samples(hail_context: None) -> None:  # noq
 @pytest.mark.parametrize(
     "variant_freq_threshold,haplotype_freq_threshold,expected_count",
     [
-        (0.0, 0.0, 457),
+        (0.0, 0.0, 459),
         (0.005, 0.0, 283),
-        (0.0, 0.005, 43),
-        (0.005, 0.005, 35),
+        (0.0, 0.005, 31),
+        (0.005, 0.005, 31),
     ],
 )
 def test_compute_haplotypes(
@@ -909,8 +924,8 @@ def test_compute_haplotypes_no_variants(
     [
         (0.0, 0.0, 1195),
         (0.005, 0.0, 884),
-        (0.0, 0.005, 796),
-        (0.005, 0.005, 670),
+        (0.0, 0.005, 781),
+        (0.005, 0.005, 678),
     ],
 )
 def test_compute_haplotypes_chrx_nonpar(

--- a/divref/tests/tools/test_compute_haplotypes.py
+++ b/divref/tests/tools/test_compute_haplotypes.py
@@ -754,6 +754,12 @@ def test_compute_metrics_tie_breaks_to_smallest_index(
     ])
     rows = _compute_metrics(ht, n_pops=2).collect()
     assert rows[0].max_pop == 0
+    # `all_pop_freqs` is sorted by `empirical_AF` descending via `hl.sorted`. With ties on
+    # the primary key, Hail's sort stability is undocumented; this assertion pins the
+    # current observed order so a future Hail upgrade that changes stability will surface
+    # here rather than as a flake downstream. If this assertion ever needs to flip,
+    # consider adding a secondary tie-break key on `pop` ascending in `_compute_metrics`.
+    assert [s.pop for s in rows[0].all_pop_freqs] == [0, 1]
 
 
 def test_apply_containment_dedup_canonical_three_rows(

--- a/divref/tests/tools/test_create_duckdb_index.py
+++ b/divref/tests/tools/test_create_duckdb_index.py
@@ -1,0 +1,173 @@
+"""Tests for the create_duckdb_index tool."""
+
+from pathlib import Path
+
+import hail as hl
+import polars
+import pytest
+
+from divref.tools.create_duckdb_index import export_sequences_table_to_tsv
+
+
+def _make_sequences_ht() -> hl.Table:
+    """
+    Build a 2-row, 2-pop synthetic sequences HT mirroring the schema fed to the exporter.
+
+    Row 0 has entries for both joint pops in `all_pop_freqs`; row 1 has only pop 0, simulating
+    a source that doesn't cover pop 1 — exercises the `dict.get(i, missing_struct)` lookup.
+    """
+    freq_struct = hl.tstruct(AF=hl.tfloat64, AC=hl.tint32)
+    pop_freq_struct = hl.tstruct(
+        pop=hl.tint32,
+        empirical_AC=hl.tint64,
+        empirical_AF=hl.tfloat64,
+        fraction_phased=hl.tfloat64,
+        estimated_gnomad_AF=hl.tfloat64,
+    )
+    schema = hl.tstruct(
+        sequence=hl.tstr,
+        sequence_length=hl.tint32,
+        sequence_id=hl.tstr,
+        n_variants=hl.tint32,
+        contig=hl.tstr,
+        start=hl.tint32,
+        end=hl.tint32,
+        popmax_empirical_AF=hl.tfloat64,
+        popmax_empirical_AC=hl.tint64,
+        source=hl.tstr,
+        estimated_gnomad_AF=hl.tfloat64,
+        fraction_phased=hl.tfloat64,
+        max_pop=hl.tint32,
+        variant_strs=hl.tarray(hl.tstr),
+        gnomad_freqs=hl.tarray(hl.tarray(freq_struct)),
+        all_pop_freqs=hl.tarray(pop_freq_struct),
+    )
+    rows = [
+        {
+            "sequence": "ACGT",
+            "sequence_length": 4,
+            "sequence_id": "DR-1.0-0",
+            "n_variants": 2,
+            "contig": "chr1",
+            "start": 99,
+            "end": 130,
+            "popmax_empirical_AF": 0.42,
+            "popmax_empirical_AC": 42,
+            "source": "HGDP_haplotype",
+            "estimated_gnomad_AF": 0.07,
+            "fraction_phased": 1.40,
+            "max_pop": 0,
+            "variant_strs": ["chr1:100:A:T", "chr1:120:C:G"],
+            "gnomad_freqs": [
+                [{"AF": 0.05, "AC": 5}, {"AF": 0.04, "AC": 4}],
+                [{"AF": 0.07, "AC": 7}, {"AF": 0.05, "AC": 5}],
+            ],
+            "all_pop_freqs": [
+                {
+                    "pop": 0,
+                    "empirical_AC": 42,
+                    "empirical_AF": 0.42,
+                    "fraction_phased": 1.40,
+                    "estimated_gnomad_AF": 0.07,
+                },
+                {
+                    "pop": 1,
+                    "empirical_AC": 19,
+                    "empirical_AF": 0.38,
+                    "fraction_phased": 1.52,
+                    "estimated_gnomad_AF": 0.05,
+                },
+            ],
+        },
+        {
+            "sequence": "GGCC",
+            "sequence_length": 4,
+            "sequence_id": "DR-1.0-1",
+            "n_variants": 1,
+            "contig": "chr1",
+            "start": 199,
+            "end": 230,
+            "popmax_empirical_AF": 0.10,
+            "popmax_empirical_AC": 5,
+            "source": "gnomAD_variant",
+            "estimated_gnomad_AF": 0.10,
+            "fraction_phased": 1.0,
+            "max_pop": 0,
+            "variant_strs": ["chr1:200:G:C"],
+            "gnomad_freqs": [
+                [{"AF": 0.10, "AC": 10}, {"AF": 0.0, "AC": 0}],
+            ],
+            "all_pop_freqs": [
+                {
+                    "pop": 0,
+                    "empirical_AC": 5,
+                    "empirical_AF": 0.10,
+                    "fraction_phased": 1.0,
+                    "estimated_gnomad_AF": 0.10,
+                },
+            ],
+        },
+    ]
+    return hl.Table.parallelize(rows, schema=schema)
+
+
+def test_export_sequences_table_to_tsv_per_pop_columns(
+    hail_context: None,  # noqa: ARG001
+    tmp_path: Path,
+) -> None:
+    """Per-pop flat columns are emitted for every joint pop, with nulls where source absent."""
+    ht = _make_sequences_ht()
+    out_file = tmp_path / "sequences.tsv.bgz"
+    joint_pops_legend = ["afr", "amr"]
+
+    export_sequences_table_to_tsv(ht=ht, out_file=out_file, joint_pops_legend=joint_pops_legend)
+
+    df = polars.read_csv(out_file, separator="\t", null_values=["NA", "null"])
+
+    # Renamed scalar columns are present; pre-rename names are gone.
+    assert "popmax_estimated_gnomad_AF" in df.columns
+    assert "popmax_fraction_phased" in df.columns
+    assert "estimated_gnomad_AF" not in df.columns
+    assert "fraction_phased" not in df.columns
+
+    # `max_pop` integer index resolved to label via the legend.
+    assert df["max_pop"].to_list() == ["afr", "afr"]
+
+    # Per-pop flat columns present for every joint pop.
+    for pop in joint_pops_legend:
+        for field in (
+            "empirical_AC",
+            "empirical_AF",
+            "fraction_phased",
+            "estimated_gnomad_AF",
+        ):
+            assert f"{field}_{pop}" in df.columns
+
+    # gnomAD_AF_{pop} columns still emitted (comma-delimited per-variant strings).
+    assert df["gnomAD_AF_afr"][0] == "0.05000,0.07000"
+    assert df["gnomAD_AF_amr"][0] == "0.04000,0.05000"
+
+    # Row 0: both pops have data.
+    assert df["empirical_AC_afr"][0] == 42
+    assert df["empirical_AF_afr"][0] == pytest.approx(0.42)
+    assert df["fraction_phased_afr"][0] == pytest.approx(1.40)
+    assert df["estimated_gnomad_AF_afr"][0] == pytest.approx(0.07)
+    assert df["empirical_AC_amr"][0] == 19
+    assert df["empirical_AF_amr"][0] == pytest.approx(0.38)
+    assert df["fraction_phased_amr"][0] == pytest.approx(1.52)
+    assert df["estimated_gnomad_AF_amr"][0] == pytest.approx(0.05)
+
+    # Row 1: only pop 0 present in all_pop_freqs; pop 1's flat columns must be null.
+    assert df["empirical_AC_afr"][1] == 5
+    assert df["empirical_AF_afr"][1] == pytest.approx(0.10)
+    assert df["fraction_phased_afr"][1] == pytest.approx(1.0)
+    assert df["estimated_gnomad_AF_afr"][1] == pytest.approx(0.10)
+    assert df["empirical_AC_amr"][1] is None
+    assert df["empirical_AF_amr"][1] is None
+    assert df["fraction_phased_amr"][1] is None
+    assert df["estimated_gnomad_AF_amr"][1] is None
+
+    # Scalar `popmax_*` columns match the max_pop entry (pop 0 in both rows).
+    assert df["popmax_empirical_AF"][0] == pytest.approx(0.42)
+    assert df["popmax_fraction_phased"][0] == pytest.approx(1.40)
+    assert df["popmax_estimated_gnomad_AF"][0] == pytest.approx(0.07)

--- a/divref/tests/tools/test_remap_divref.py
+++ b/divref/tests/tools/test_remap_divref.py
@@ -47,6 +47,8 @@ def create_haplotype(
         variants: Comma-separated variant strings (chrom:pos:ref:alt).
         gnomad_afs: Mapping from pop label to comma-delimited per-variant AF string. Defaults to
             a five-population (afr/amr/eas/nfe/sas) dict if not provided.
+        estimated_gnomad_af_per_pop: Mapping from pop label to per-pop scalar estimated gnomAD
+            AF. Defaults to a five-population dict if not provided.
         **kwargs: Additional fields passed to Haplotype.
 
     Returns:

--- a/divref/tests/tools/test_remap_divref.py
+++ b/divref/tests/tools/test_remap_divref.py
@@ -17,6 +17,14 @@ _DEFAULT_GNOMAD_AFS: dict[str, str] = {
     "sas": "0.13,0.23,0.33",
 }
 
+_DEFAULT_ESTIMATED_GNOMAD_AF_PER_POP: dict[str, float] = {
+    "afr": 0.05,
+    "amr": 0.15,
+    "eas": 0.08,
+    "nfe": 0.10,
+    "sas": 0.07,
+}
+
 
 def create_haplotype(
     sequence_id: str = "test_hap",
@@ -25,6 +33,7 @@ def create_haplotype(
     n_variants: int = 3,
     variants: str = "1:500:A:T,1:505:C:G,1:510:T:A",
     gnomad_afs: dict[str, str] | None = None,
+    estimated_gnomad_af_per_pop: dict[str, float | None] | None = None,
     **kwargs: Any,
 ) -> Haplotype:
     """
@@ -44,10 +53,10 @@ def create_haplotype(
         A Haplotype instance for use in tests.
     """
     defaults: dict[str, Any] = {
-        "fraction_phased": 1.0,
+        "popmax_fraction_phased": 1.0,
         "popmax_empirical_AF": 0.25,
         "popmax_empirical_AC": 1000,
-        "estimated_gnomad_AF": 0.15,
+        "popmax_estimated_gnomad_AF": 0.15,
         "max_pop": "amr",
         "source": "test_source",
     }
@@ -59,6 +68,11 @@ def create_haplotype(
         n_variants=n_variants,
         variants=variants,
         gnomad_afs=dict(_DEFAULT_GNOMAD_AFS) if gnomad_afs is None else gnomad_afs,
+        estimated_gnomad_af_per_pop=(
+            dict(_DEFAULT_ESTIMATED_GNOMAD_AF_PER_POP)
+            if estimated_gnomad_af_per_pop is None
+            else estimated_gnomad_af_per_pop
+        ),
         **defaults,
     )
 
@@ -314,27 +328,32 @@ def test_parse_pop_freqs_na_treated_as_missing() -> None:
 
 
 def test_from_row_splits_per_pop_columns() -> None:
-    """Haplotype.from_row should pull gnomAD_AF_* columns into gnomad_afs by pop label."""
+    """Haplotype.from_row should pull per-pop columns into the dict fields by pop label."""
     pops_legend = ["afr", "amr", "eas"]
     row: dict[str, Any] = {
         "sequence_id": "row_hap",
         "sequence": "ACGT",
         "sequence_length": 4,
         "n_variants": 1,
-        "fraction_phased": 1.0,
+        "popmax_fraction_phased": 1.0,
         "popmax_empirical_AF": 0.5,
         "popmax_empirical_AC": 10,
-        "estimated_gnomad_AF": 0.5,
+        "popmax_estimated_gnomad_AF": 0.5,
         "max_pop": "afr",
         "variants": "chr1:100:A:T",
         "source": "test",
         "gnomAD_AF_afr": "0.5",
         "gnomAD_AF_amr": "0.3",
         "gnomAD_AF_eas": "NA",
+        "estimated_gnomad_AF_afr": 0.5,
+        "estimated_gnomad_AF_amr": 0.3,
+        "estimated_gnomad_AF_eas": None,
     }
     hap = Haplotype.from_row(row, pops_legend)
     assert hap.gnomad_afs == {"afr": "0.5", "amr": "0.3", "eas": "NA"}
     assert list(hap.gnomad_afs.keys()) == pops_legend
+    assert hap.estimated_gnomad_af_per_pop == {"afr": 0.5, "amr": 0.3, "eas": None}
+    assert list(hap.estimated_gnomad_af_per_pop.keys()) == pops_legend
 
 
 # ---------------------------------------------------------------------------

--- a/pixi.lock
+++ b/pixi.lock
@@ -4097,7 +4097,7 @@ packages:
 - pypi: ./divref
   name: divref
   version: 0.1.0
-  sha256: a4f1e749e8791b1816dfa6ccb5a24ed13c2f7e41ce754fabaad21b872a5533df
+  sha256: ea086b3e07d2a4d7b4fad4ebeb905e9987326a8e0acb600ef3f02fe2d8008de7
   requires_dist:
   - defopt~=6.4
   - duckdb>=1.0


### PR DESCRIPTION
## Bug

In the per-sample-adjacency rewrite of `compute_haplotypes`, `_compute_metrics` was setting `min_variant_frequency` to `min over component variants of gnomad_freqs[var][max_pop].AF` (the gnomAD sites AF). This is the same `hl.min` that appears inside `estimated_gnomad_AF`'s formula:

    estimated_gnomad_AF = min over variants of (gnomad_freqs[var][max_pop].AF * fraction_phased)
    fraction_phased     = max_empirical_AF / min_variant_frequency

With gnomAD AFs on both sides of the formula, the gnomAD multiplier cancels exactly and the formula collapses to:

    estimated_gnomad_AF == max_empirical_AF

The unit test `test_compute_metrics_single_population` confirms the collapse with `0.4 * 0.03 / 0.4`. The original two-pass-union algorithm on `main` doesn't have this collapse: it uses the **local** HGDP+1KG `call_stats` alt AF as `min_variant_frequency`, distinct from the gnomAD sites AF, so the heuristic does real work.

## Fix

Restore `min_variant_frequency` to use `frequencies_by_pop[var][max_pop].AF[1]` — the local call_stats alt AF. With local AF in the denominator and gnomAD AF in the numerator, the formula no longer cancels and `estimated_gnomad_AF` is once again a meaningful LD-aware extrapolation of haplotype frequency into the broader gnomAD population.

## New `all_pop_freqs` shape

While restoring the formula, `all_pop_freqs` is also extended to bundle all four per-pop frequency-derived metrics in one struct array (sorted by `empirical_AF` descending):

    all_pop_freqs: array<struct(pop, empirical_AC, empirical_AF, fraction_phased, estimated_gnomad_AF)>

Each entry's `fraction_phased` and `estimated_gnomad_AF` use *that pop's own* denominators, not `max_pop`'s.

The scalar `min_variant_frequency`, `fraction_phased`, and `estimated_gnomad_AF` continue to be exposed at the top level as `all_pop_freqs[max_pop]` for backward compatibility, but downstream tools can now consume the full per-pop view.

## DuckDB schema additions (breaking)

The DuckDB `sequences` table now exposes every joint pop's frequency-derived metrics as flat columns, mirroring the existing `gnomAD_AF_{POP}` pattern:

- `empirical_AC_{POP}` — scalar allele count per pop
- `empirical_AF_{POP}` — scalar empirical AF per pop
- `fraction_phased_{POP}` — per-pop phase ratio (`1.0` for `gnomAD_variant` rows)
- `estimated_gnomad_AF_{POP}` — per-pop projected AF (equal to `empirical_AF_{POP}` for `gnomAD_variant` rows)

Missing where the pop has no source data for that row.

**Renamed scalar columns** (for consistency with `popmax_empirical_AF/AC`):

| Before | After |
|---|---|
| `fraction_phased` | `popmax_fraction_phased` |
| `estimated_gnomad_AF` | `popmax_estimated_gnomad_AF` |

Breaking change for SQL queries against the prior names. README's index column table updated accordingly.

## `remap_divref` output additions

New output column `estimated_gnomad_af_per_pop_json`: JSON-encoded `{pop: float | null}` per row, mirroring the existing `population_frequencies_json` column.

## Documentation & test coverage

- `_compute_metrics` docstring spells out the per-pop semantics of `all_pop_freqs` (each entry uses that pop's own denominators).
- README old-vs-new algorithm comparison clarified: the old algorithm's `min_variant_frequency` used gnomAD-sites AF; the new (corrected) algorithm uses local HGDP+1KG `call_stats.AF[1]`.
- New tests:
  - `test_compute_metrics_absent_pop_key_skips_variant_in_min` — pins `hl.min`'s missing-skip semantics for the absent-pop-key path.
  - `test_compute_metrics_tie_breaks_to_smallest_index` — pins `all_pop_freqs` ordering on AF ties (Hail sort stability is undocumented; this catches a future Hail upgrade that flips stability).
  - `test_compute_metrics_picks_max_population` extended with explicit per-pop denominator assertions.
  - `test_create_duckdb_index.py` (new file) — focused test that `export_sequences_table_to_tsv` emits the new flat columns and writes nulls for absent pops. Broader `create_duckdb_index` coverage will follow in a separate PR.

## Expected-count parametrize changes

These integration-test count shifts are the *expected* downstream effect of the fixed semantics, not regressions:

| Test parametrize | Old | New | Δ | Reason |
|---|---:|---:|---:|---|
| `chr1 [0.0-0.0]` | 457 | 459 | +2 | `min_variant_frequency > 0` filter now more inclusive (local AF always > 0 for haplotype carriers in max_pop; gnomAD AF could be 0). |
| `chr1 [0.005-0.0]` | 283 | 283 | — | Variant filter dominates; no change. |
| `chr1 [0.0-0.005]` | 43 | 31 | −12 | Real heuristic produces smaller `estimated_gnomad_AF` for many haplotypes; 12 drop below 0.5%. |
| `chr1 [0.005-0.005]` | 35 | 31 | −4 | Same as above, smaller delta because variant filter already removed many. |
| `chrX [0.0-0.0]` | 1195 | 1195 | — | No change from new `min_variant_frequency > 0` behavior on this fixture. |
| `chrX [0.005-0.0]` | 884 | 884 | — | Variant filter dominates. |
| `chrX [0.0-0.005]` | 796 | 781 | −15 | Heuristic shift. |
| `chrX [0.005-0.005]` | 670 | 678 | +8 | Heuristic shift in the opposite direction — gains from `variant_freq=0.005` combined with the new heuristic computation outweigh losses for this fixture. |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-population phasing and per-pop estimated gnomAD AF metrics added to haplotype and sequence exports; per-pop flat columns are now emitted in TSV outputs.
  * Scalar max-pop columns renamed to popmax_fraction_phased and popmax_estimated_gnomad_AF.

* **Bug Fixes**
  * Haplotype frequency computation corrected to use local population AFs, fixing prior estimated gnomAD AF collapse.

* **Documentation**
  * Sequences table schema and haplotype computation notes updated to reflect new columns and corrected semantics.

* **Tests**
  * Tests updated and new tests added to validate per-pop columns and corrected metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/divref-wf/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->