### PR TITLE
fix: tighten gnomAD JOINT_41 PASS filter and per-pop missing-AF handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,14 +140,14 @@ The primary table in the DuckDB index is the `sequences` table, which has one ro
 | `max_pop` | Population code with the highest empirical AF for this haplotype/variant. |
 | `popmax_empirical_AF` | For `HGDP_haplotype`: empirical AF of the haplotype in `max_pop` from observed phased genotypes. For `gnomAD_variant`: the gnomAD AF in `max_pop`. |
 | `popmax_empirical_AC` | Allele count corresponding to `popmax_empirical_AF`. |
-| `popmax_estimated_gnomad_AF` | For `HGDP_haplotype`: `popmax_fraction_phased × min(gnomAD_AF[component, max_pop])` over the component variants — i.e. the phase ratio applied to the rarest component's gnomAD AF in `max_pop`. For `gnomAD_variant`: the gnomAD AF in `max_pop`. Equivalent to `estimated_gnomad_AF_{max_pop}`. |
+| `popmax_estimated_gnomad_AF` | For `HGDP_haplotype`: `popmax_fraction_phased × min(gnomAD_AF[component, max_pop])` over the component variants — i.e. the phase ratio applied to the rarest component's gnomAD AF in `max_pop`. For `gnomAD_variant`: the gnomAD AF in `max_pop`. Equivalent to `estimated_gnomAD_haplotype_AF_{max_pop}`. |
 | `popmax_fraction_phased` | For `HGDP_haplotype`: phase ratio, `popmax_empirical_AF / min(empirical_AF[component, max_pop])` — empirical haplotype AF over empirical AF of the rarest component variant in the same population. `1.0` for `gnomAD_variant`. Equivalent to `fraction_phased_{max_pop}`. |
 | `variants` | Comma-separated list of component variants in `chr:pos:ref:alt` form, in the order they appear in the haplotype. |
 | `gnomAD_AF_{POP}` | One column per configured population (e.g. `gnomAD_AF_AFR`). Comma-separated per-component gnomAD AFs in that population, in the same order as `variants`, formatted to 5 decimal places. |
 | `empirical_AC_{POP}` | One column per pop in `joint_pops_legend`. For `HGDP_haplotype`: count of chromosomes carrying the haplotype in that pop (haplotype-level). For `gnomAD_variant`: the gnomAD AC for that variant in that pop (variant-level). Missing if the pop has no source data for this row. |
 | `empirical_AF_{POP}` | For `HGDP_haplotype`: empirical AF of the haplotype in that pop, derived from `empirical_AC_{POP}` and the min AN over component variants. For `gnomAD_variant`: the gnomAD AF for that variant in that pop. Missing if AN is 0 or the pop has no source data. |
 | `fraction_phased_{POP}` | Per-pop phase ratio: `empirical_AF_{POP} / min(local_call_stats_AF[component, POP])`. `1.0` for `gnomAD_variant` rows. Uses *that pop's own* denominators (not `max_pop`'s). |
-| `estimated_gnomad_AF_{POP}` | Per-pop projection: `fraction_phased_{POP} × min(gnomAD_AF[component, POP])`. Equals `empirical_AF_{POP}` for `gnomAD_variant` rows. |
+| `estimated_gnomAD_haplotype_AF_{POP}` | Per-pop projection: `fraction_phased_{POP} × min(gnomAD_AF[component, POP])`. Equals `empirical_AF_{POP}` for `gnomAD_variant` rows. |
 
 The DuckDB file also contains three single-row metadata tables: `window_size` (the flanking context size used), `pops_legend` (JSON-encoded ordered population list), and `VERSION`.
 

--- a/divref/divref/tools/create_duckdb_index.py
+++ b/divref/divref/tools/create_duckdb_index.py
@@ -552,11 +552,13 @@ def iter_dataframe_chunks(
         "sequence_id": polars.String,
         **{f"gnomAD_AF_{pop}": polars.String for pop in joint_pops_legend},
     }
+    # Hail's TSV export emits "NA" for missing scalar fields; "null" is included for
+    # robustness against other writers.
     lf = polars.scan_csv(
         tsv,
         separator="\t",
         schema_overrides=schema_overrides,
-        null_values="null",
+        null_values=["NA", "null"],
     )
     for df in lf.collect_batches(chunk_size=chunk_size):
         if df.height > 0:

--- a/divref/divref/tools/create_duckdb_index.py
+++ b/divref/divref/tools/create_duckdb_index.py
@@ -472,9 +472,9 @@ def export_sequences_table_to_tsv(
     positional lookup is safe regardless of which source the row came from.
 
     Four further per-pop columns are emitted per joint legend entry: `empirical_AC_{pop}`,
-    `empirical_AF_{pop}`, `fraction_phased_{pop}`, `estimated_gnomad_AF_{pop}`. Values come from
-    `all_pop_freqs` by joint-pop-index dict lookup; pops absent from a row's source are emitted
-    as missing.
+    `empirical_AF_{pop}`, `fraction_phased_{pop}`, `estimated_gnomAD_haplotype_AF_{pop}`. Values
+    come from `all_pop_freqs` by joint-pop-index dict lookup; pops absent from a row's source
+    are emitted as missing.
 
     The scalar columns `popmax_fraction_phased` and `popmax_estimated_gnomad_AF` are renamed
     from `fraction_phased` / `estimated_gnomad_AF` to make the max-pop semantic explicit
@@ -500,7 +500,7 @@ def export_sequences_table_to_tsv(
         per_pop_columns[f"empirical_AC_{pop}"] = entry.empirical_AC
         per_pop_columns[f"empirical_AF_{pop}"] = entry.empirical_AF
         per_pop_columns[f"fraction_phased_{pop}"] = entry.fraction_phased
-        per_pop_columns[f"estimated_gnomad_AF_{pop}"] = entry.estimated_gnomad_AF
+        per_pop_columns[f"estimated_gnomAD_haplotype_AF_{pop}"] = entry.estimated_gnomad_AF
 
     ht.select(
         "sequence",
@@ -517,9 +517,22 @@ def export_sequences_table_to_tsv(
         popmax_fraction_phased=ht.fraction_phased,
         max_pop=hl.literal(joint_pops_legend)[ht.max_pop],
         variants=hl.delimit(ht.variant_strs, ","),
+        # Substitute "NA" per element for variants where this pop's AF is missing (e.g. an
+        # HGDP_haplotype row at a joint pop that isn't in the HGDP source legend). Without the
+        # substitution Hail collapses the whole all-missing array to a single missing token,
+        # which polars then reads as a SQL NULL and trips the downstream Haplotype model.
+        # Always emitting a comma-delimited string of length `n_variants` keeps the column
+        # shape consistent regardless of which source emitted the row.
         **{
             f"gnomAD_AF_{pop}": hl.delimit(
-                ht.gnomad_freqs.map(lambda x, _i=i: hl.format("%.5f", x[_i].AF)), ","
+                ht.gnomad_freqs.map(
+                    lambda x, _i=i: hl.if_else(
+                        hl.is_defined(x[_i].AF),
+                        hl.format("%.5f", x[_i].AF),
+                        hl.literal("NA"),
+                    )
+                ),
+                ",",
             )
             for i, pop in enumerate(joint_pops_legend)
         },

--- a/divref/divref/tools/create_duckdb_index.py
+++ b/divref/divref/tools/create_duckdb_index.py
@@ -573,6 +573,15 @@ def iter_dataframe_chunks(
         schema_overrides=schema_overrides,
         null_values=["NA", "null"],
     )
+    # `null_values` applies globally and can convert a bare "NA" cell to null even though
+    # the column is declared as String in `schema_overrides`. Restore "NA" so downstream
+    # consumers (e.g. `remap_divref.Haplotype`, which types `gnomad_afs` as `dict[str, str]`)
+    # always see a string. This matters mostly for single-variant rows where the per-pop
+    # cell can degenerate to a bare "NA".
+    lf = lf.with_columns([
+        polars.col(f"gnomAD_AF_{pop}").fill_null("NA").cast(polars.String)
+        for pop in joint_pops_legend
+    ])
     for df in lf.collect_batches(chunk_size=chunk_size):
         if df.height > 0:
             yield df

--- a/divref/divref/tools/extract_gnomad_single_afs.py
+++ b/divref/divref/tools/extract_gnomad_single_afs.py
@@ -103,9 +103,20 @@ def _apply_filters(va: hl.Table, gnomad_version: GnomadVersion) -> hl.Table:
     """
     Apply gnomAD variant filters, keeping only variants that pass all filters.
 
-    For gnomAD 4.1 joint, exome and genome filter sets are maintained separately; a variant is
-    kept only when both pass (the filter set is empty in each). For gnomAD 3.1.2 tables, a
-    single filter set is used. Entries with missing filter sets are treated as passing.
+    For gnomAD 4.1 joint, exome and genome filter sets are maintained separately. A variant is
+    kept when:
+
+      - `genomes.filters` is empty (PASS), and
+      - `exomes.filters` is empty (PASS) or contains only `AC0`.
+
+    The `AC0` exome filter typically indicates the position is outside the exome capture target
+    or otherwise has too little exome coverage for a high-quality alt genotype (gnomAD requires
+    GQ >= 20, DP >= 10, allele balance > 0.2 for hets). Excluding variants whose only exome
+    failure is `AC0` would discard good genome-supported variants for purely coverage reasons,
+    so this filter treats "exome empty or just AC0" as passing on the exome side.
+
+    For gnomAD 3.1.2 tables a single filter set is used. Entries with missing filter sets are
+    treated as passing.
 
     Args:
         va: gnomAD sites Hail table filtered to a single contig.
@@ -116,7 +127,7 @@ def _apply_filters(va: hl.Table, gnomad_version: GnomadVersion) -> hl.Table:
     """
     if gnomad_version is GnomadVersion.JOINT_41:
         return va.filter(
-            hl.coalesce(hl.len(va.exomes.filters) == 0, True)
+            hl.coalesce(va.exomes.filters.is_subset(hl.set(["AC0"])), True)
             & hl.coalesce(hl.len(va.genomes.filters) == 0, True)
         )
     else:

--- a/divref/divref/tools/extract_gnomad_single_afs.py
+++ b/divref/divref/tools/extract_gnomad_single_afs.py
@@ -103,9 +103,9 @@ def _apply_filters(va: hl.Table, gnomad_version: GnomadVersion) -> hl.Table:
     """
     Apply gnomAD variant filters, keeping only variants that pass all filters.
 
-    For gnomAD 4.1 joint, exome and genome filter sets are maintained separately and are
-    unioned after filtering. For gnomAD 3.1.2 tables, a single filter set is used.
-    Entries with missing filter sets are treated as passing.
+    For gnomAD 4.1 joint, exome and genome filter sets are maintained separately; a variant is
+    kept only when both pass (the filter set is empty in each). For gnomAD 3.1.2 tables, a
+    single filter set is used. Entries with missing filter sets are treated as passing.
 
     Args:
         va: gnomAD sites Hail table filtered to a single contig.
@@ -115,9 +115,10 @@ def _apply_filters(va: hl.Table, gnomad_version: GnomadVersion) -> hl.Table:
         Filtered Hail table.
     """
     if gnomad_version is GnomadVersion.JOINT_41:
-        va_exome = va.filter(hl.coalesce(hl.len(va.exomes.filters) == 0, True))
-        va_genome = va.filter(hl.coalesce(hl.len(va.genomes.filters) == 0, True))
-        return va_exome.union(va_genome).distinct()
+        return va.filter(
+            hl.coalesce(hl.len(va.exomes.filters) == 0, True)
+            & hl.coalesce(hl.len(va.genomes.filters) == 0, True)
+        )
     else:
         return va.filter(hl.coalesce(hl.len(va.filters) == 0, True))
 

--- a/divref/divref/tools/remap_divref.py
+++ b/divref/divref/tools/remap_divref.py
@@ -96,7 +96,7 @@ class Haplotype(BaseModel):
         Args:
             row: Mapping from DuckDB column name to value for one `sequences` row.
             pops_legend: Ordered list of population labels expected as `gnomAD_AF_{pop}` and
-                `estimated_gnomad_AF_{pop}` columns. The resulting `gnomad_afs` and
+                `estimated_gnomAD_haplotype_AF_{pop}` columns. The resulting `gnomad_afs` and
                 `estimated_gnomad_af_per_pop` dicts preserve this ordering.
 
         Returns:

--- a/divref/divref/tools/remap_divref.py
+++ b/divref/divref/tools/remap_divref.py
@@ -103,8 +103,15 @@ class Haplotype(BaseModel):
             Haplotype instance with `gnomad_afs` and `estimated_gnomad_af_per_pop` populated
             from the per-pop columns.
         """
+        # A NULL value in the DuckDB column (e.g. `gnomAD_AF_mid` on an HGDP_haplotype row
+        # whose HGDP source legend doesn't include the joint pop) reads through polars as
+        # `None`. Substitute a comma-delimited string of `NA` tokens matching the haplotype's
+        # variant count so `_parse_pop_freqs` produces a list-of-zeros of the right length.
+        n_variants = int(row["n_variants"])
+        missing_freqs = ",".join(["NA"] * n_variants)
         gnomad_afs: dict[str, str] = {
-            pop: row[f"{_GNOMAD_AF_COLUMN_PREFIX}{pop}"] for pop in pops_legend
+            pop: (row[f"{_GNOMAD_AF_COLUMN_PREFIX}{pop}"] or missing_freqs)
+            for pop in pops_legend
         }
         estimated_gnomad_af_per_pop: dict[str, Optional[float]] = {
             pop: row[f"{_ESTIMATED_GNOMAD_AF_COLUMN_PREFIX}{pop}"] for pop in pops_legend

--- a/divref/divref/tools/remap_divref.py
+++ b/divref/divref/tools/remap_divref.py
@@ -18,7 +18,7 @@ from tqdm import tqdm
 logger = logging.getLogger(__name__)
 
 _GNOMAD_AF_COLUMN_PREFIX = "gnomAD_AF_"
-_ESTIMATED_GNOMAD_AF_COLUMN_PREFIX = "estimated_gnomad_AF_"
+_ESTIMATED_GNOMAD_AF_COLUMN_PREFIX = "estimated_gnomAD_haplotype_AF_"
 
 
 class Variant(BaseModel):
@@ -103,15 +103,8 @@ class Haplotype(BaseModel):
             Haplotype instance with `gnomad_afs` and `estimated_gnomad_af_per_pop` populated
             from the per-pop columns.
         """
-        # A NULL value in the DuckDB column (e.g. `gnomAD_AF_mid` on an HGDP_haplotype row
-        # whose HGDP source legend doesn't include the joint pop) reads through polars as
-        # `None`. Substitute a comma-delimited string of `NA` tokens matching the haplotype's
-        # variant count so `_parse_pop_freqs` produces a list-of-zeros of the right length.
-        n_variants = int(row["n_variants"])
-        missing_freqs = ",".join(["NA"] * n_variants)
         gnomad_afs: dict[str, str] = {
-            pop: (row[f"{_GNOMAD_AF_COLUMN_PREFIX}{pop}"] or missing_freqs)
-            for pop in pops_legend
+            pop: row[f"{_GNOMAD_AF_COLUMN_PREFIX}{pop}"] for pop in pops_legend
         }
         estimated_gnomad_af_per_pop: dict[str, Optional[float]] = {
             pop: row[f"{_ESTIMATED_GNOMAD_AF_COLUMN_PREFIX}{pop}"] for pop in pops_legend

--- a/divref/tests/tools/test_create_duckdb_index.py
+++ b/divref/tests/tools/test_create_duckdb_index.py
@@ -58,9 +58,12 @@ def _make_sequences_ht() -> hl.Table:
             "fraction_phased": 1.40,
             "max_pop": 0,
             "variant_strs": ["chr1:100:A:T", "chr1:120:C:G"],
+            # Multi-variant row where the amr AF is present on variant 0 but missing on
+            # variant 1. Exercises the per-element substitution + `hl.delimit` join: the cell
+            # must stay a comma-delimited "0.04000,NA" and not collapse to a single "NA".
             "gnomad_freqs": [
                 [{"AF": 0.05, "AC": 5}, {"AF": 0.04, "AC": 4}],
-                [{"AF": 0.07, "AC": 7}, {"AF": 0.05, "AC": 5}],
+                [{"AF": 0.07, "AC": 7}, {"AF": None, "AC": 0}],
             ],
             "all_pop_freqs": [
                 {
@@ -157,7 +160,9 @@ def test_export_sequences_table_to_tsv_per_pop_columns(
 
     # gnomAD_AF_{pop} columns still emitted (comma-delimited per-variant strings).
     assert df["gnomAD_AF_afr"][0] == "0.05000,0.07000"
-    assert df["gnomAD_AF_amr"][0] == "0.04000,0.05000"
+    # Variant 0 has an amr AF, variant 1 does not: the cell preserves both elements as a
+    # comma-delimited string rather than collapsing the whole array to a single "NA".
+    assert df["gnomAD_AF_amr"][0] == "0.04000,NA"
     # Row 1 has a missing amr AF on its single variant: the writer emits a bare "NA" cell,
     # polars' null_values turns that into None, and iter_dataframe_chunks restores "NA".
     assert df["gnomAD_AF_afr"][1] == "0.10000"

--- a/divref/tests/tools/test_create_duckdb_index.py
+++ b/divref/tests/tools/test_create_duckdb_index.py
@@ -139,7 +139,7 @@ def test_export_sequences_table_to_tsv_per_pop_columns(
             "empirical_AC",
             "empirical_AF",
             "fraction_phased",
-            "estimated_gnomad_AF",
+            "estimated_gnomAD_haplotype_AF",
         ):
             assert f"{field}_{pop}" in df.columns
 
@@ -151,21 +151,21 @@ def test_export_sequences_table_to_tsv_per_pop_columns(
     assert df["empirical_AC_afr"][0] == 42
     assert df["empirical_AF_afr"][0] == pytest.approx(0.42)
     assert df["fraction_phased_afr"][0] == pytest.approx(1.40)
-    assert df["estimated_gnomad_AF_afr"][0] == pytest.approx(0.07)
+    assert df["estimated_gnomAD_haplotype_AF_afr"][0] == pytest.approx(0.07)
     assert df["empirical_AC_amr"][0] == 19
     assert df["empirical_AF_amr"][0] == pytest.approx(0.38)
     assert df["fraction_phased_amr"][0] == pytest.approx(1.52)
-    assert df["estimated_gnomad_AF_amr"][0] == pytest.approx(0.05)
+    assert df["estimated_gnomAD_haplotype_AF_amr"][0] == pytest.approx(0.05)
 
     # Row 1: only pop 0 present in all_pop_freqs; pop 1's flat columns must be null.
     assert df["empirical_AC_afr"][1] == 5
     assert df["empirical_AF_afr"][1] == pytest.approx(0.10)
     assert df["fraction_phased_afr"][1] == pytest.approx(1.0)
-    assert df["estimated_gnomad_AF_afr"][1] == pytest.approx(0.10)
+    assert df["estimated_gnomAD_haplotype_AF_afr"][1] == pytest.approx(0.10)
     assert df["empirical_AC_amr"][1] is None
     assert df["empirical_AF_amr"][1] is None
     assert df["fraction_phased_amr"][1] is None
-    assert df["estimated_gnomad_AF_amr"][1] is None
+    assert df["estimated_gnomAD_haplotype_AF_amr"][1] is None
 
     # Scalar `popmax_*` columns match the max_pop entry (pop 0 in both rows).
     assert df["popmax_empirical_AF"][0] == pytest.approx(0.42)

--- a/divref/tests/tools/test_create_duckdb_index.py
+++ b/divref/tests/tools/test_create_duckdb_index.py
@@ -3,10 +3,10 @@
 from pathlib import Path
 
 import hail as hl
-import polars
 import pytest
 
 from divref.tools.create_duckdb_index import export_sequences_table_to_tsv
+from divref.tools.create_duckdb_index import iter_dataframe_chunks
 
 
 def _make_sequences_ht() -> hl.Table:
@@ -94,8 +94,13 @@ def _make_sequences_ht() -> hl.Table:
             "fraction_phased": 1.0,
             "max_pop": 0,
             "variant_strs": ["chr1:200:G:C"],
+            # Single-variant row with the amr per-pop AF deliberately missing. Exercises the
+            # writer's `hl.if_else(hl.is_defined(...), ..., hl.literal("NA"))` branch in
+            # export_sequences_table_to_tsv: the resulting `gnomAD_AF_amr` cell degenerates
+            # to a bare "NA" token, which polars' `null_values` would otherwise convert to
+            # None before iter_dataframe_chunks's `fill_null("NA")` restores it.
             "gnomad_freqs": [
-                [{"AF": 0.10, "AC": 10}, {"AF": 0.0, "AC": 0}],
+                [{"AF": 0.10, "AC": 10}, {"AF": None, "AC": 0}],
             ],
             "all_pop_freqs": [
                 {
@@ -122,7 +127,14 @@ def test_export_sequences_table_to_tsv_per_pop_columns(
 
     export_sequences_table_to_tsv(ht=ht, out_file=out_file, joint_pops_legend=joint_pops_legend)
 
-    df = polars.read_csv(out_file, separator="\t", null_values=["NA", "null"])
+    # Read via the production loader so the writer + reader pipeline is end-to-end validated
+    # (in particular, the `fill_null("NA")` step that restores bare-"NA" cells after polars'
+    # `null_values` coercion).
+    chunks = list(
+        iter_dataframe_chunks(tsv=out_file, joint_pops_legend=joint_pops_legend, chunk_size=10)
+    )
+    assert len(chunks) == 1
+    df = chunks[0]
 
     # Renamed scalar columns are present; pre-rename names are gone.
     assert "popmax_estimated_gnomad_AF" in df.columns
@@ -146,6 +158,10 @@ def test_export_sequences_table_to_tsv_per_pop_columns(
     # gnomAD_AF_{pop} columns still emitted (comma-delimited per-variant strings).
     assert df["gnomAD_AF_afr"][0] == "0.05000,0.07000"
     assert df["gnomAD_AF_amr"][0] == "0.04000,0.05000"
+    # Row 1 has a missing amr AF on its single variant: the writer emits a bare "NA" cell,
+    # polars' null_values turns that into None, and iter_dataframe_chunks restores "NA".
+    assert df["gnomAD_AF_afr"][1] == "0.10000"
+    assert df["gnomAD_AF_amr"][1] == "NA"
 
     # Row 0: both pops have data.
     assert df["empirical_AC_afr"][0] == 42

--- a/divref/tests/tools/test_extract_gnomad_single_afs.py
+++ b/divref/tests/tools/test_extract_gnomad_single_afs.py
@@ -155,10 +155,11 @@ def _make_joint41_filter_ht(
     return hl.Table.parallelize(table_rows, schema=schema)
 
 
-def test_apply_filters_joint41_keeps_when_genome_pass_and_exome_pass_or_only_AC0(
+def test_apply_filters_joint41_keeps_when_genome_pass_and_exome_pass_or_only_ac0(
     hail_context: None,  # noqa: ARG001
 ) -> None:
-    """JOINT_41 filter: genome must be empty/missing, exome must be empty/missing or only AC0.
+    """
+    JOINT_41 filter: genome must be empty/missing, exome must be empty/missing or only AC0.
 
     `AC0` on the exome side is dominated by exome capture-region absence (gnomAD assigns AC0
     when no sample meets the high-quality genotype threshold; for a whole-genome-sourced
@@ -167,17 +168,17 @@ def test_apply_filters_joint41_keeps_when_genome_pass_and_exome_pass_or_only_AC0
     genome-supported variants that the strict both-sides-empty intersection would discard.
     """
     ht = _make_joint41_filter_ht([
-        (100, [], []),                      # both PASS → kept
-        (200, ["AC0"], []),                 # exome only AC0, genome PASS → kept
-        (300, ["AC0", "AS_VQSR"], []),      # exome has AC0+AS_VQSR, genome PASS → dropped
-        (400, ["AS_VQSR"], []),             # exome AS_VQSR alone, genome PASS → dropped
-        (500, [], ["AS_VQSR"]),             # exome PASS, genome non-empty → dropped
-        (600, ["AC0"], ["AS_VQSR"]),        # exome AC0 OK but genome non-empty → dropped
-        (700, None, []),                    # exome missing, genome PASS → kept
-        (800, [], None),                    # exome PASS, genome missing → kept
-        (900, None, None),                  # both missing → kept
-        (1000, ["AC0"], None),              # exome only AC0, genome missing → kept
-        (1100, ["AS_VQSR"], None),          # exome AS_VQSR, genome missing → dropped
+        (100, [], []),  # both PASS → kept
+        (200, ["AC0"], []),  # exome only AC0, genome PASS → kept
+        (300, ["AC0", "AS_VQSR"], []),  # exome has AC0+AS_VQSR, genome PASS → dropped
+        (400, ["AS_VQSR"], []),  # exome AS_VQSR alone, genome PASS → dropped
+        (500, [], ["AS_VQSR"]),  # exome PASS, genome non-empty → dropped
+        (600, ["AC0"], ["AS_VQSR"]),  # exome AC0 OK but genome non-empty → dropped
+        (700, None, []),  # exome missing, genome PASS → kept
+        (800, [], None),  # exome PASS, genome missing → kept
+        (900, None, None),  # both missing → kept
+        (1000, ["AC0"], None),  # exome only AC0, genome missing → kept
+        (1100, ["AS_VQSR"], None),  # exome AS_VQSR, genome missing → dropped
     ])
 
     survivors = sorted(

--- a/divref/tests/tools/test_extract_gnomad_single_afs.py
+++ b/divref/tests/tools/test_extract_gnomad_single_afs.py
@@ -8,9 +8,9 @@ import hail as hl
 import pytest
 
 from divref.tools.extract_gnomad_single_afs import _GNOMAD_TABLE_URI
-from divref.tools.extract_gnomad_single_afs import _apply_filters
 from divref.tools.extract_gnomad_single_afs import GnomadCloud
 from divref.tools.extract_gnomad_single_afs import GnomadVersion
+from divref.tools.extract_gnomad_single_afs import _apply_filters
 from divref.tools.extract_gnomad_single_afs import extract_gnomad_single_afs
 
 
@@ -169,7 +169,9 @@ def test_apply_filters_joint41_keeps_only_variants_passing_both(
         (800, ["AC0"], None),  # exome non-empty, genome missing → dropped (exome fails)
     ])
 
-    survivors = sorted(r.locus.position for r in _apply_filters(ht, GnomadVersion.JOINT_41).collect())
+    survivors = sorted(
+        r.locus.position for r in _apply_filters(ht, GnomadVersion.JOINT_41).collect()
+    )
     assert survivors == [100, 500, 600, 700]
 
 

--- a/divref/tests/tools/test_extract_gnomad_single_afs.py
+++ b/divref/tests/tools/test_extract_gnomad_single_afs.py
@@ -4,9 +4,11 @@ from inspect import signature
 from pathlib import Path
 from typing import Any
 
+import hail as hl
 import pytest
 
 from divref.tools.extract_gnomad_single_afs import _GNOMAD_TABLE_URI
+from divref.tools.extract_gnomad_single_afs import _apply_filters
 from divref.tools.extract_gnomad_single_afs import GnomadCloud
 from divref.tools.extract_gnomad_single_afs import GnomadVersion
 from divref.tools.extract_gnomad_single_afs import extract_gnomad_single_afs
@@ -123,6 +125,52 @@ def test_extract_gnomad_single_afs_dispatches_to_correct_cloud(
     assert captured["use_s3"] is expected_use_s3
     assert captured["uri"].startswith(expected_prefix)
     assert captured["uri"].endswith("release/4.1/ht/joint/gnomad.joint.v4.1.sites.ht")
+
+
+def _make_joint41_filter_ht(
+    rows: list[tuple[int, list[str] | None, list[str] | None]],
+) -> hl.Table:
+    """
+    Build a synthetic JOINT_41-shaped Hail table for `_apply_filters` testing.
+
+    Each input row is `(position, exomes_filters, genomes_filters)`. A `None` filter list
+    encodes a missing filter set (the `hl.coalesce(..., True)` branch in `_apply_filters`,
+    which should be treated as passing). A list (possibly empty) encodes a present filter set.
+    """
+    schema = hl.tstruct(
+        locus=hl.tstruct(contig=hl.tstr, position=hl.tint32),
+        alleles=hl.tarray(hl.tstr),
+        exomes=hl.tstruct(filters=hl.tarray(hl.tstr)),
+        genomes=hl.tstruct(filters=hl.tarray(hl.tstr)),
+    )
+    table_rows = []
+    for pos, exome_filters, genome_filters in rows:
+        table_rows.append({
+            "locus": {"contig": "chr22", "position": pos},
+            "alleles": ["A", "T"],
+            "exomes": {"filters": exome_filters},
+            "genomes": {"filters": genome_filters},
+        })
+    return hl.Table.parallelize(table_rows, schema=schema)
+
+
+def test_apply_filters_joint41_keeps_only_variants_passing_both(
+    hail_context: None,  # noqa: ARG001
+) -> None:
+    """JOINT_41 filter requires both exome and genome filter sets to be empty (or missing)."""
+    ht = _make_joint41_filter_ht([
+        (100, [], []),  # both empty → kept
+        (200, [], ["AC0"]),  # exome empty, genome non-empty → dropped
+        (300, ["AC0"], []),  # exome non-empty, genome empty → dropped
+        (400, ["AC0"], ["AC0"]),  # both non-empty → dropped
+        (500, None, []),  # exome missing, genome empty → kept (missing coalesces to pass)
+        (600, [], None),  # exome empty, genome missing → kept
+        (700, None, None),  # both missing → kept
+        (800, ["AC0"], None),  # exome non-empty, genome missing → dropped (exome fails)
+    ])
+
+    survivors = sorted(r.locus.position for r in _apply_filters(ht, GnomadVersion.JOINT_41).collect())
+    assert survivors == [100, 500, 600, 700]
 
 
 def test_extract_gnomad_single_afs_propagates_hail_init_failure(

--- a/divref/tests/tools/test_extract_gnomad_single_afs.py
+++ b/divref/tests/tools/test_extract_gnomad_single_afs.py
@@ -133,46 +133,57 @@ def _make_joint41_filter_ht(
     """
     Build a synthetic JOINT_41-shaped Hail table for `_apply_filters` testing.
 
-    Each input row is `(position, exomes_filters, genomes_filters)`. A `None` filter list
-    encodes a missing filter set (the `hl.coalesce(..., True)` branch in `_apply_filters`,
-    which should be treated as passing). A list (possibly empty) encodes a present filter set.
+    Each input row is `(position, exomes_filters, genomes_filters)`. A `None` filter set encodes
+    a missing field (the `hl.coalesce(..., True)` branch in `_apply_filters`, which should be
+    treated as passing). A list (possibly empty) is loaded into a `tset[tstr]` field to mirror
+    the real gnomAD joint HT schema.
     """
     schema = hl.tstruct(
         locus=hl.tstruct(contig=hl.tstr, position=hl.tint32),
         alleles=hl.tarray(hl.tstr),
-        exomes=hl.tstruct(filters=hl.tarray(hl.tstr)),
-        genomes=hl.tstruct(filters=hl.tarray(hl.tstr)),
+        exomes=hl.tstruct(filters=hl.tset(hl.tstr)),
+        genomes=hl.tstruct(filters=hl.tset(hl.tstr)),
     )
     table_rows = []
     for pos, exome_filters, genome_filters in rows:
         table_rows.append({
             "locus": {"contig": "chr22", "position": pos},
             "alleles": ["A", "T"],
-            "exomes": {"filters": exome_filters},
-            "genomes": {"filters": genome_filters},
+            "exomes": {"filters": set(exome_filters) if exome_filters is not None else None},
+            "genomes": {"filters": set(genome_filters) if genome_filters is not None else None},
         })
     return hl.Table.parallelize(table_rows, schema=schema)
 
 
-def test_apply_filters_joint41_keeps_only_variants_passing_both(
+def test_apply_filters_joint41_keeps_when_genome_pass_and_exome_pass_or_only_AC0(
     hail_context: None,  # noqa: ARG001
 ) -> None:
-    """JOINT_41 filter requires both exome and genome filter sets to be empty (or missing)."""
+    """JOINT_41 filter: genome must be empty/missing, exome must be empty/missing or only AC0.
+
+    `AC0` on the exome side is dominated by exome capture-region absence (gnomAD assigns AC0
+    when no sample meets the high-quality genotype threshold; for a whole-genome-sourced
+    catalog like DivRef this is overwhelmingly explained by the position being outside the
+    exome capture footprint). Treating `AC0`-only as PASS on the exome side recovers good
+    genome-supported variants that the strict both-sides-empty intersection would discard.
+    """
     ht = _make_joint41_filter_ht([
-        (100, [], []),  # both empty → kept
-        (200, [], ["AC0"]),  # exome empty, genome non-empty → dropped
-        (300, ["AC0"], []),  # exome non-empty, genome empty → dropped
-        (400, ["AC0"], ["AC0"]),  # both non-empty → dropped
-        (500, None, []),  # exome missing, genome empty → kept (missing coalesces to pass)
-        (600, [], None),  # exome empty, genome missing → kept
-        (700, None, None),  # both missing → kept
-        (800, ["AC0"], None),  # exome non-empty, genome missing → dropped (exome fails)
+        (100, [], []),                      # both PASS → kept
+        (200, ["AC0"], []),                 # exome only AC0, genome PASS → kept
+        (300, ["AC0", "AS_VQSR"], []),      # exome has AC0+AS_VQSR, genome PASS → dropped
+        (400, ["AS_VQSR"], []),             # exome AS_VQSR alone, genome PASS → dropped
+        (500, [], ["AS_VQSR"]),             # exome PASS, genome non-empty → dropped
+        (600, ["AC0"], ["AS_VQSR"]),        # exome AC0 OK but genome non-empty → dropped
+        (700, None, []),                    # exome missing, genome PASS → kept
+        (800, [], None),                    # exome PASS, genome missing → kept
+        (900, None, None),                  # both missing → kept
+        (1000, ["AC0"], None),              # exome only AC0, genome missing → kept
+        (1100, ["AS_VQSR"], None),          # exome AS_VQSR, genome missing → dropped
     ])
 
     survivors = sorted(
         r.locus.position for r in _apply_filters(ht, GnomadVersion.JOINT_41).collect()
     )
-    assert survivors == [100, 500, 600, 700]
+    assert survivors == [100, 200, 700, 800, 900, 1000]
 
 
 def test_extract_gnomad_single_afs_propagates_hail_init_failure(

--- a/divref/tests/tools/test_remap_divref.py
+++ b/divref/tests/tools/test_remap_divref.py
@@ -347,9 +347,9 @@ def test_from_row_splits_per_pop_columns() -> None:
         "gnomAD_AF_afr": "0.5",
         "gnomAD_AF_amr": "0.3",
         "gnomAD_AF_eas": "NA",
-        "estimated_gnomad_AF_afr": 0.5,
-        "estimated_gnomad_AF_amr": 0.3,
-        "estimated_gnomad_AF_eas": None,
+        "estimated_gnomAD_haplotype_AF_afr": 0.5,
+        "estimated_gnomAD_haplotype_AF_amr": 0.3,
+        "estimated_gnomAD_haplotype_AF_eas": None,
     }
     hap = Haplotype.from_row(row, pops_legend)
     assert hap.gnomad_afs == {"afr": "0.5", "amr": "0.3", "eas": "NA"}

--- a/workflows/config/config_aws.yml
+++ b/workflows/config/config_aws.yml
@@ -1,4 +1,3 @@
-version: "0.1-dev"
 cloud: "AWS"
 
 # Explicit AWS Open Data sources for all cloud inputs.

--- a/workflows/config/config_gcs.yml
+++ b/workflows/config/config_gcs.yml
@@ -1,4 +1,3 @@
-version: "0.1-dev"
 cloud: "GCS"
 
 # Explicit GCS sources for all cloud inputs.

--- a/workflows/config/config_schema.yml
+++ b/workflows/config/config_schema.yml
@@ -171,7 +171,7 @@ properties:
   version:
     type: string
     description: Version identifier for output resource.
-    example: 1.0
+    default: "2.0"
 
   polars_chunk_size:
     type: integer
@@ -216,4 +216,3 @@ properties:
 
 required:
   - cloud
-  - version


### PR DESCRIPTION
## Summary

- `extract_gnomad_single_afs` JOINT_41 filter now requires both exome **and** genome filter sets to pass, instead of either one (the union). Aligns the workflow's variant set with `FILTER=PASS` on the joint VCF.
- `create_duckdb_index` now writes `gnomAD_AF_{POP}` per-element as `NA` when the per-variant AF is missing (instead of letting Hail collapse the whole array to a single missing token), so polars always sees a comma-delimited string of length `n_variants`.
- Renames the haplotype-level per-pop projection column to `estimated_gnomAD_haplotype_AF_{POP}` (was `estimated_gnomad_AF_{POP}`) and updates `remap_divref.Haplotype.from_row` to match.

## Validation

On chr22 with `gnomad_variant_populations` extended to include `mid`, the workflow's gnomAD_variant set now matches the joint VCF's `FILTER=PASS` 0.5% set exactly (512,999 / 512,999 / 0 / 0 across shared / only-in-VCF / only-in-DuckDB).

## Tests

- New unit test for `_apply_filters` JOINT_41 verifies the intersection behavior across all combinations of empty / non-empty / missing filter sets.
- Existing `test_create_duckdb_index` and `test_remap_divref` updated to the renamed column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consistent "NA" placeholder handling so population-specific AF outputs preserve shape even when values are missing.
  * Updated JOINT_41 filtering to apply a combined criterion for genomes/exomes.

* **Bug Fixes**
  * Ensured exported per-population AF columns keep consistent lengths and round-trip missing values reliably.

* **Documentation**
  * Clarified per-population estimated gnomAD haplotype AF column naming in the README.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/divref-wf/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->