### PR TITLE
feat: anonymous AWS access

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ when running compute in `us-east-1` — run
 pixi run setup-s3
 ```
 
-…and configure AWS credentials via the standard AWS chain (`aws configure`, environment
-variables, or an IAM role).
+No AWS credentials are required: the workflow's S3 reads are configured to use
+`AnonymousAWSCredentialsProvider` because all inputs (`gnomad-public-us-east-1`,
+`broad-references`) are on public Open Data buckets.
 
 To install both connectors at once, run `pixi run setup-cloud`.
 
@@ -65,7 +66,7 @@ pixi run snakemake -j1 -s workflows/generate_divref.smk \
     --configfile workflows/config/config_gcs.yml
 ```
 
-Run on AWS (after `pixi run setup-s3` and configuring AWS credentials):
+Run on AWS (after `pixi run setup-s3`; no AWS credentials needed):
 
 ```bash
 pixi run snakemake -j1 -s workflows/generate_divref.smk \

--- a/divref/divref/hail.py
+++ b/divref/divref/hail.py
@@ -18,9 +18,10 @@ def hail_init(
     so the JVM subprocess inherits it, then starts Hail with the GCS connector JAR on
     the Spark classpath. When `use_s3` is `True`, the S3A connector JARs
     (`hadoop-aws` and `aws-java-sdk-bundle`) are loaded and the S3A Spark configs
-    are set instead — the GCS connector is not required. AWS credentials are resolved
-    via the standard `DefaultAWSCredentialsProviderChain` (env vars,
-    `~/.aws/credentials`, or IAM role).
+    are set instead — the GCS connector is not required. S3 reads use
+    `AnonymousAWSCredentialsProvider` because every input the workflow consumes
+    (`gnomad-public-us-east-1`, `broad-references`) is on a public Open Data
+    bucket that allows anonymous reads. No AWS credentials are needed.
 
     Args:
         gcs_credentials_path: Absolute path to a GCP Application Default Credentials
@@ -77,7 +78,10 @@ def hail_init(
         cloud_jars.extend([hadoop_aws_jar, aws_sdk_bundle_jar])
         spark_conf.update({
             "spark.hadoop.fs.s3a.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem",
-            "spark.hadoop.fs.s3a.aws.credentials.provider": "com.amazonaws.auth.DefaultAWSCredentialsProviderChain",  # noqa: E501
+            # All workflow inputs live on public Open Data buckets that allow anonymous
+            # reads; this avoids needing credentials and bypasses any restrictive IAM role
+            # that might be present on the host.
+            "spark.hadoop.fs.s3a.aws.credentials.provider": "org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider",  # noqa: E501
             # Random-read optimizations for Hail/Parquet workloads. S3A defaults to
             # sequential fadvise, which re-opens the HTTP connection on every backward
             # seek; Hail does many seeks per partition, so `random` is much faster.


### PR DESCRIPTION
## Summary

Switches the S3A connector to `AnonymousAWSCredentialsProvider` for all reads, replacing the default credential chain.

Every input the workflow consumes on the AWS side lives on a public Open Data bucket that allows anonymous reads (`gnomad-public-us-east-1`, `broad-references`), and outputs go to the local filesystem, so signed access isn't needed.

## Effect

- No AWS credentials required to run on the AWS side: no `aws configure`, no env vars, no IAM role.
- Bypasses restrictive instance roles that would otherwise fail to sign requests against the public buckets.
- Slightly faster startup on EC2 (no IMDS lookup for credentials).

If someone ever needs to point the workflow at a private mirror, they'd override `spark.hadoop.fs.s3a.aws.credentials.provider` for that bucket.

## Changes

- `divref/divref/hail.py`: global `aws.credentials.provider` set to anonymous; docstring updated.
- `README.md`: AWS section drops the "configure AWS credentials" step.