### PR TITLE
docs: correct chrX haplotype coverage in config schema

### DIFF
--- a/workflows/config/config_schema.yml
+++ b/workflows/config/config_schema.yml
@@ -35,8 +35,9 @@ properties:
     minItems: 1
     uniqueItems: true
     description: |
-      List of chromosomes to generate the resource for. Haplotypes are only computed for autosomes
-      (chr1-chr22); chrX and chrY, if listed, contribute gnomAD single variants only.
+      List of chromosomes to generate the resource for. Haplotypes are computed for the autosomes
+      (chr1-chr22) and chrX (chrX non-PAR applies a haploid-male ploidy correction); chrY, if
+      listed, contributes gnomAD single variants only.
     default: ["chr1", "chr2", "chr3", "chr4", "chr5", "chr6", "chr7", "chr8", "chr9", "chr10", "chr11", "chr12", "chr13", "chr14", "chr15", "chr16", "chr17", "chr18", "chr19", "chr20", "chr21", "chr22", "chrX", "chrY"]
 
   hgdp_1kg_populations:


### PR DESCRIPTION
## Summary
The `chromosomes` field description in `config_schema.yml` claimed haplotypes are computed only for the autosomes, but the workflow actually computes them for **chr1–22 and chrX**.

`generate_divref.smk` defines:
```python
_HAPLOTYPE_CONTIGS = frozenset(f"chr{n}" for n in range(1, 23)) | {"chrX"}
```
and `compute_haplotypes` carries a dedicated haploid-male non-PAR ploidy correction precisely for chrX. Only chrY contributes gnomAD single variants only. The README is already consistent (its chrX karyotype/ploidy note only makes sense if chrX haplotypes are computed); this brings the schema in line.

## Change
- Reword the `chromosomes` description: haplotypes cover the autosomes (chr1–22) **and chrX** (haploid-male non-PAR correction); chrY is single-variants only.

No code or behavior change — documentation only.

## Verification
- YAML parses and the JSON Schema validates (`Draft202012Validator.check_schema`).

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)