### PR TITLE
test: cover remap_divref orchestration; close connection; fix index discovery

### DIFF
--- a/divref/divref/tools/remap_divref.py
+++ b/divref/divref/tools/remap_divref.py
@@ -1,5 +1,6 @@
 """Tool to remap DivRef haplotype coordinates to reference genome coordinates."""
 
+import contextlib
 import csv
 import json
 import logging
@@ -267,19 +268,54 @@ def _translate_coordinate_to_ref(
     return v_end_ref + (coord - variant_intervals[last_smaller_variant][1])
 
 
+def _find_index_in_cwd() -> Optional[Path]:
+    """
+    Search the current working directory recursively for a `.duckdb` file.
+
+    Returns:
+        The first `.duckdb` file found while walking the tree, or None if there is none.
+    """
+    for root, _dirs, files in os.walk(Path.cwd()):
+        for file in files:
+            if file.endswith(".duckdb"):
+                return Path(root) / file
+    return None
+
+
 def _get_index_connection(index_path: Optional[Path]) -> duckdb.DuckDBPyConnection:
     if index_path is None:
-        for root, _dirs, files in os.walk(Path.cwd()):
-            for file in files:
-                if file.endswith(".duckdb"):
-                    index_path = Path(root) / file
-                    break
+        index_path = _find_index_in_cwd()
     if index_path is None:
         raise RuntimeError(
             "Unable to find a DuckDB index file. Pass --index-path or run from the "
             "same directory as the index file."
         )
     return duckdb.connect(str(index_path))
+
+
+def _read_metadata_scalar(conn: duckdb.DuckDBPyConnection, query: str, table: str) -> Any:
+    """
+    Read the single scalar value from a one-row metadata table, raising if it is absent.
+
+    Args:
+        conn: Open DuckDB connection to a DivRef index.
+        query: The `SELECT` statement reading the table (a trusted literal, not user input).
+        table: The table's name, used only for the error message.
+
+    Returns:
+        The first column of the table's single row.
+
+    Raises:
+        RuntimeError: If the table is missing (not in the catalog) or empty — i.e. not a valid
+            DivRef index.
+    """
+    try:
+        row = conn.execute(query).fetchone()
+    except duckdb.CatalogException:
+        row = None
+    if row is None:
+        raise RuntimeError(f"Index is missing {table} table — ensure this is a valid DivRef index.")
+    return row[0]
 
 
 def remap_divref(  # noqa: C901
@@ -300,13 +336,11 @@ def remap_divref(  # noqa: C901
     Args:
         input_path: Path to the CALITAS output file.
         output_path: Path to write the remapped output file.
-        index_path: Path to the DivRef DuckDB index file. If not provided, the tool
-            searches the directory containing this script for a .duckdb file.
+        index_path: Path to the DivRef DuckDB index file. If not provided, the current working
+            directory is searched recursively and the first .duckdb file found is used.
         separator: Field delimiter used in both input and output files.
         batch_size: Number of rows to process per database query batch.
     """
-    conn = _get_index_connection(index_path)
-
     df: pd.DataFrame = pd.read_csv(input_path, sep=separator)
     chrom_field: str = "chromosome"
     start_field: str = "coordinate_start"
@@ -329,99 +363,89 @@ def remap_divref(  # noqa: C901
     if df[chrom_field].dtype != object:
         df[chrom_field] = df[chrom_field].astype(str)
 
-    version_row = conn.execute("SELECT * FROM VERSION").fetchone()
-    if version_row is None:
-        raise RuntimeError("Index is missing VERSION table — ensure this is a valid DivRef index.")
-    version: str = version_row[0]
-
-    window_size_row = conn.execute("SELECT * FROM window_size").fetchone()
-    if window_size_row is None:
-        raise RuntimeError(
-            "Index is missing window_size table — ensure this is a valid DivRef index."
+    with contextlib.closing(_get_index_connection(index_path)) as conn:
+        version: str = _read_metadata_scalar(conn, "SELECT * FROM VERSION", "VERSION")
+        window_size: int = _read_metadata_scalar(conn, "SELECT * FROM window_size", "window_size")
+        joint_pops_legend: list[str] = json.loads(
+            _read_metadata_scalar(conn, "SELECT * FROM joint_pops_legend", "joint_pops_legend")
         )
-    window_size: int = window_size_row[0]
 
-    joint_pops_legend_row = conn.execute("SELECT * FROM joint_pops_legend").fetchone()
-    if joint_pops_legend_row is None:
-        raise RuntimeError(
-            "Index is missing joint_pops_legend table — ensure this is a valid DivRef index."
-        )
-    joint_pops_legend: list[str] = json.loads(joint_pops_legend_row[0])
+        contigs: list[str] = []
+        starts: list[int] = []
+        ends: list[int] = []
+        variants_involved: list[str] = []
+        all_variants: list[str] = []
+        n_variants_involved: list[int] = []
+        popmax_empirical_af: list[float] = []
+        popmax_empirical_ac: list[int] = []
+        max_pop: list[str] = []
+        source: list[str] = []
+        haplotype_filter: list[str] = []
+        # One column per pop in the joint legend. `gnomad_af_per_pop` holds the comma-delimited
+        # per-variant AF strings (matches DuckDB's `gnomAD_AF_{POP}` columns verbatim);
+        # `estimated_gnomad_af_per_pop` holds the per-pop scalar haplotype-level estimated AF.
+        gnomad_af_per_pop: dict[str, list[str]] = {pop: [] for pop in joint_pops_legend}
+        estimated_gnomad_af_per_pop: dict[str, list[Optional[float]]] = {
+            pop: [] for pop in joint_pops_legend
+        }
 
-    contigs: list[str] = []
-    starts: list[int] = []
-    ends: list[int] = []
-    variants_involved: list[str] = []
-    all_variants: list[str] = []
-    n_variants_involved: list[int] = []
-    popmax_empirical_af: list[float] = []
-    popmax_empirical_ac: list[int] = []
-    max_pop: list[str] = []
-    source: list[str] = []
-    haplotype_filter: list[str] = []
-    # One column per pop in the joint legend. `gnomad_af_per_pop` holds the comma-delimited
-    # per-variant AF strings (matches DuckDB's `gnomAD_AF_{POP}` columns verbatim);
-    # `estimated_gnomad_af_per_pop` holds the per-pop scalar haplotype-level estimated AF.
-    gnomad_af_per_pop: dict[str, list[str]] = {pop: [] for pop in joint_pops_legend}
-    estimated_gnomad_af_per_pop: dict[str, list[Optional[float]]] = {
-        pop: [] for pop in joint_pops_legend
-    }
+        for batch_start in tqdm(range(0, len(df), batch_size)):
+            batch_end = min(batch_start + batch_size, len(df))
+            batch_df = df.iloc[batch_start:batch_end]
+            batch_hap_ids = batch_df[chrom_field].tolist()
 
-    for batch_start in tqdm(range(0, len(df), batch_size)):
-        batch_end = min(batch_start + batch_size, len(df))
-        batch_df = df.iloc[batch_start:batch_end]
-        batch_hap_ids = batch_df[chrom_field].tolist()
+            results = conn.execute(
+                """
+                SELECT * FROM sequences
+                WHERE sequences.sequence_id IN (SELECT unnest($1::STRING[]))
+                """,
+                [batch_hap_ids],
+            ).fetchall()
 
-        results = conn.execute(
-            """
-            SELECT * FROM sequences
-            WHERE sequences.sequence_id IN (SELECT unnest($1::STRING[]))
-            """,
-            [batch_hap_ids],
-        ).fetchall()
+            columns = [desc[0] for desc in conn.description]
+            id_to_hap: dict[str, Haplotype] = {}
+            for row in results:
+                hap = Haplotype.from_row(dict(zip(columns, row, strict=True)), joint_pops_legend)
+                id_to_hap[hap.sequence_id] = hap
 
-        columns = [desc[0] for desc in conn.description]
-        id_to_hap: dict[str, Haplotype] = {}
-        for row in results:
-            hap = Haplotype.from_row(dict(zip(columns, row, strict=True)), joint_pops_legend)
-            id_to_hap[hap.sequence_id] = hap
+            for _, df_row in batch_df.iterrows():
+                start: int = df_row[start_field]
+                end: int = df_row[end_field]
+                hap_id: str = df_row[chrom_field]
+                strand: str = df_row[strand_field]
+                padded_target: str = df_row[padded_target_field]
+                target: str = df_row[unpadded_target_field]
 
-        for _, df_row in batch_df.iterrows():
-            start: int = df_row[start_field]
-            end: int = df_row[end_field]
-            hap_id: str = df_row[chrom_field]
-            strand: str = df_row[strand_field]
-            padded_target: str = df_row[padded_target_field]
-            target: str = df_row[unpadded_target_field]
+                padded_len_adj = len(padded_target.replace("-", "")) - len(target)
+                if strand == "+":
+                    end += padded_len_adj
+                else:
+                    start -= padded_len_adj
 
-            padded_len_adj = len(padded_target.replace("-", "")) - len(target)
-            if strand == "+":
-                end += padded_len_adj
-            else:
-                start -= padded_len_adj
+                found_hap = id_to_hap.get(hap_id)
+                if found_hap is None:
+                    raise RuntimeError(
+                        f"Unable to find haplotype for {hap_id} — ensure you are aligning against "
+                        f"the same DivRef version as this index (DivRef-v{version})"
+                    )
+                rm = found_hap.reference_mapping(start, end, window_size)
 
-            found_hap = id_to_hap.get(hap_id)
-            if found_hap is None:
-                raise RuntimeError(
-                    f"Unable to find haplotype for {hap_id} — ensure you are aligning against "
-                    f"the same DivRef version as this index (DivRef-v{version})"
-                )
-            rm = found_hap.reference_mapping(start, end, window_size)
-
-            contigs.append(rm.chromosome)
-            starts.append(rm.start)
-            ends.append(rm.end)
-            all_variants.append(found_hap.variants)
-            variants_involved.append(rm.variants_involved_str())
-            n_variants_involved.append(len(rm.variants_involved))
-            popmax_empirical_af.append(found_hap.popmax_empirical_af)
-            popmax_empirical_ac.append(found_hap.popmax_empirical_ac)
-            max_pop.append(found_hap.max_pop)
-            source.append(found_hap.source)
-            haplotype_filter.append(found_hap.haplotype_filter)
-            for pop in joint_pops_legend:
-                gnomad_af_per_pop[pop].append(found_hap.gnomad_afs[pop])
-                estimated_gnomad_af_per_pop[pop].append(found_hap.estimated_gnomad_af_per_pop[pop])
+                contigs.append(rm.chromosome)
+                starts.append(rm.start)
+                ends.append(rm.end)
+                all_variants.append(found_hap.variants)
+                variants_involved.append(rm.variants_involved_str())
+                n_variants_involved.append(len(rm.variants_involved))
+                popmax_empirical_af.append(found_hap.popmax_empirical_af)
+                popmax_empirical_ac.append(found_hap.popmax_empirical_ac)
+                max_pop.append(found_hap.max_pop)
+                source.append(found_hap.source)
+                haplotype_filter.append(found_hap.haplotype_filter)
+                for pop in joint_pops_legend:
+                    gnomad_af_per_pop[pop].append(found_hap.gnomad_afs[pop])
+                    estimated_gnomad_af_per_pop[pop].append(
+                        found_hap.estimated_gnomad_af_per_pop[pop]
+                    )
 
     df["divref_sequence_id"] = df[chrom_field]
     df["divref_start"] = df[start_field]

--- a/divref/tests/tools/test_remap_divref.py
+++ b/divref/tests/tools/test_remap_divref.py
@@ -111,6 +111,8 @@ def test_deletion_shifts_coordinates() -> None:
 
     assert rm.first_variant_index == 1
     assert rm.last_variant_index == 2
+    assert rm.start == 504
+    assert rm.end == 511
 
 
 def test_insertion_shifts_coordinates() -> None:
@@ -124,6 +126,8 @@ def test_insertion_shifts_coordinates() -> None:
 
     assert rm.first_variant_index == 1
     assert rm.last_variant_index == 1
+    assert rm.start == 503
+    assert rm.end == 506
 
 
 def test_no_variants_in_range() -> None:
@@ -152,6 +156,8 @@ def test_complex_multi_indel_mapping() -> None:
 
     assert rm.first_variant_index == 0
     assert rm.last_variant_index == 2
+    assert rm.start == 499
+    assert rm.end == 513
 
 
 def test_large_insertion_with_null_frequencies() -> None:

--- a/divref/tests/tools/test_remap_divref_e2e.py
+++ b/divref/tests/tools/test_remap_divref_e2e.py
@@ -1,0 +1,265 @@
+"""End-to-end tests for the remap_divref() orchestration (CSV in, DuckDB lookup, CSV out)."""
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import pandas as pd
+import pytest
+
+from divref.tools.remap_divref import _find_index_in_cwd
+from divref.tools.remap_divref import _get_index_connection
+from divref.tools.remap_divref import remap_divref
+
+_POPS: tuple[str, ...] = ("afr", "amr")
+_VARIANTS: str = "chr1:500:A:T,chr1:505:C:G,chr1:510:T:A"
+
+
+def _seq_row(
+    sequence_id: str,
+    variants: str = _VARIANTS,
+    *,
+    haplotype_filter: str = "PASS",
+    pops: Iterable[str] = _POPS,
+) -> dict[str, Any]:
+    """Build one `sequences` row dict with the columns remap_divref reads."""
+    row: dict[str, Any] = {
+        "sequence_id": sequence_id,
+        "sequence": "ACGT",
+        "sequence_length": 4,
+        "n_variants": len(variants.split(",")),
+        "popmax_fraction_phased": 1.0,
+        "popmax_empirical_AF": 0.25,
+        "popmax_empirical_AC": 1000,
+        "popmax_estimated_gnomad_AF": 0.15,
+        "max_pop": "amr",
+        "variants": variants,
+        "source": "HGDP_haplotype",
+        "haplotype_filter": haplotype_filter,
+    }
+    for pop in pops:
+        row[f"gnomAD_AF_{pop}"] = "0.1,0.2,0.3"
+        row[f"estimated_gnomAD_haplotype_AF_{pop}"] = 0.05
+    return row
+
+
+def _build_index(
+    db_path: Path,
+    *,
+    seq_rows: list[dict[str, Any]],
+    version: str = "9.9",
+    window_size: int = 10,
+    pops: Iterable[str] = _POPS,
+    skip: Iterable[str] = (),
+) -> None:
+    """
+    Build a minimal DivRef DuckDB index (metadata tables + a `sequences` table).
+
+    Args:
+        db_path: Path to the DuckDB file to create.
+        seq_rows: `sequences` rows (e.g. from `_seq_row`).
+        version: Value for the VERSION table.
+        window_size: Value for the window_size table.
+        pops: Population labels for the joint_pops_legend table.
+        skip: Metadata table names to NOT create (to exercise error paths).
+    """
+    skip = set(skip)
+    with duckdb.connect(str(db_path)) as conn:
+        if "VERSION" not in skip:
+            conn.execute("CREATE TABLE VERSION AS SELECT ? AS version", [version])
+        if "window_size" not in skip:
+            conn.execute("CREATE TABLE window_size AS SELECT ? AS window_size", [window_size])
+        if "joint_pops_legend" not in skip:
+            conn.execute(
+                "CREATE TABLE joint_pops_legend AS SELECT ? AS pops_legend",
+                [json.dumps(list(pops))],
+            )
+        seq_df = pd.DataFrame(seq_rows)
+        conn.register("seq_df", seq_df)
+        conn.execute("CREATE TABLE sequences AS SELECT * FROM seq_df")
+
+
+def _write_calitas_tsv(path: Path, rows: list[dict[str, Any]]) -> Path:
+    """Write a CALITAS-style input TSV (the `chromosome` column holds the DivRef sequence id)."""
+    pd.DataFrame(rows).to_csv(path, sep="\t", index=False)
+    return path
+
+
+def _calitas_row(
+    sequence_id: str,
+    *,
+    coordinate_start: int,
+    coordinate_end: int,
+    strand: str = "+",
+    padded_target: str = "ACGTA",
+    unpadded_target_sequence: str = "ACGTA",
+) -> dict[str, Any]:
+    """Build one CALITAS input row."""
+    return {
+        "chromosome": sequence_id,
+        "coordinate_start": coordinate_start,
+        "coordinate_end": coordinate_end,
+        "strand": strand,
+        "padded_target": padded_target,
+        "unpadded_target_sequence": unpadded_target_sequence,
+    }
+
+
+def test_remap_plus_strand_appends_reference_coordinates(tmp_path: Path) -> None:
+    """A '+' strand hit is remapped to reference coordinates with the full metadata columns."""
+    db_path = tmp_path / "index.duckdb"
+    _build_index(db_path, seq_rows=[_seq_row("hapA", haplotype_filter="snp_in_deletion")])
+    input_tsv = _write_calitas_tsv(
+        tmp_path / "calitas.tsv",
+        [_calitas_row("hapA", coordinate_start=12, coordinate_end=17)],
+    )
+    output_tsv = tmp_path / "out.tsv"
+
+    remap_divref(input_path=input_tsv, output_path=output_tsv, index_path=db_path)
+
+    out = pd.read_csv(output_tsv, sep="\t")
+    row = out.iloc[0]
+    # Original DivRef-space coordinates preserved under divref_* columns.
+    assert row["divref_sequence_id"] == "hapA"
+    assert row["divref_start"] == 12
+    assert row["divref_end"] == 17
+    # Remapped reference coordinates replace the original chromosome/start/end columns.
+    assert row["chromosome"] == "chr1"
+    assert row["coordinate_start"] == 502
+    assert row["coordinate_end"] == 507
+    assert row["genome_build"] == "DivRef-v9.9"
+    assert row["all_variants"] == _VARIANTS
+    assert row["variants_involved"] == "chr1:505:C:G"
+    assert row["n_variants_involved"] == 1
+    assert row["max_pop"] == "amr"
+    assert row["variant_source"] == "HGDP_haplotype"
+    # haplotype_filter is carried through verbatim.
+    assert row["haplotype_filter"] == "snp_in_deletion"
+    # One gnomAD_AF_/estimated column per joint-legend population.
+    assert row["gnomAD_AF_afr"] == "0.1,0.2,0.3"
+    assert row["estimated_gnomAD_haplotype_AF_amr"] == 0.05
+
+
+def test_remap_minus_strand_adjusts_start_by_padding(tmp_path: Path) -> None:
+    """On the '-' strand the padding-length adjustment is subtracted from the start coordinate."""
+    db_path = tmp_path / "index.duckdb"
+    _build_index(db_path, seq_rows=[_seq_row("hapA")])
+    # padded_target has 2 more (gap-stripped) bases than the unpadded target, so padded_len_adj=2;
+    # on the '-' strand start 14 -> 12, mapping the same [12, 19) window as a hand-computed case.
+    input_tsv = _write_calitas_tsv(
+        tmp_path / "calitas.tsv",
+        [
+            _calitas_row(
+                "hapA",
+                coordinate_start=14,
+                coordinate_end=19,
+                strand="-",
+                padded_target="ACGTAA",
+                unpadded_target_sequence="ACGT",
+            )
+        ],
+    )
+    output_tsv = tmp_path / "out.tsv"
+
+    remap_divref(input_path=input_tsv, output_path=output_tsv, index_path=db_path)
+
+    row = pd.read_csv(output_tsv, sep="\t").iloc[0]
+    assert row["divref_start"] == 14  # original, unadjusted
+    assert row["coordinate_start"] == 502
+    assert row["coordinate_end"] == 509
+
+
+def test_remap_missing_required_field_raises(tmp_path: Path) -> None:
+    """An input TSV missing a required column raises ValueError before touching the index."""
+    db_path = tmp_path / "index.duckdb"
+    _build_index(db_path, seq_rows=[_seq_row("hapA")])
+    # Drop the 'strand' column.
+    bad = _calitas_row("hapA", coordinate_start=12, coordinate_end=17)
+    del bad["strand"]
+    input_tsv = _write_calitas_tsv(tmp_path / "calitas.tsv", [bad])
+
+    with pytest.raises(ValueError, match="Required fields"):
+        remap_divref(input_path=input_tsv, output_path=tmp_path / "out.tsv", index_path=db_path)
+
+
+def test_remap_unknown_haplotype_raises(tmp_path: Path) -> None:
+    """A CALITAS row whose sequence id is absent from the index raises RuntimeError."""
+    db_path = tmp_path / "index.duckdb"
+    _build_index(db_path, seq_rows=[_seq_row("hapA")])
+    input_tsv = _write_calitas_tsv(
+        tmp_path / "calitas.tsv",
+        [_calitas_row("hapMISSING", coordinate_start=12, coordinate_end=17)],
+    )
+
+    with pytest.raises(RuntimeError, match="Unable to find haplotype"):
+        remap_divref(input_path=input_tsv, output_path=tmp_path / "out.tsv", index_path=db_path)
+
+
+@pytest.mark.parametrize("missing_table", ["VERSION", "window_size", "joint_pops_legend"])
+def test_remap_missing_metadata_table_raises(tmp_path: Path, missing_table: str) -> None:
+    """A missing metadata table raises a RuntimeError naming that table."""
+    db_path = tmp_path / "index.duckdb"
+    _build_index(db_path, seq_rows=[_seq_row("hapA")], skip=[missing_table])
+    input_tsv = _write_calitas_tsv(
+        tmp_path / "calitas.tsv",
+        [_calitas_row("hapA", coordinate_start=12, coordinate_end=17)],
+    )
+
+    with pytest.raises(RuntimeError, match=missing_table):
+        remap_divref(input_path=input_tsv, output_path=tmp_path / "out.tsv", index_path=db_path)
+
+
+def test_remap_closes_the_index_connection(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """remap_divref closes the DuckDB connection it opens (no leaked handle)."""
+    db_path = tmp_path / "index.duckdb"
+    _build_index(db_path, seq_rows=[_seq_row("hapA")])
+    input_tsv = _write_calitas_tsv(
+        tmp_path / "calitas.tsv",
+        [_calitas_row("hapA", coordinate_start=12, coordinate_end=17)],
+    )
+
+    opened: list[duckdb.DuckDBPyConnection] = []
+    real_connect = duckdb.connect
+
+    def tracking_connect(*args: Any, **kwargs: Any) -> duckdb.DuckDBPyConnection:
+        conn = real_connect(*args, **kwargs)
+        opened.append(conn)
+        return conn
+
+    monkeypatch.setattr("divref.tools.remap_divref.duckdb.connect", tracking_connect)
+    remap_divref(input_path=input_tsv, output_path=tmp_path / "out.tsv", index_path=db_path)
+
+    assert opened, "expected remap_divref to open a DuckDB connection"
+    # Executing on a closed connection raises; this fails if the connection was left open.
+    with pytest.raises(duckdb.ConnectionException):
+        opened[-1].execute("SELECT 1")
+
+
+def test_get_index_connection_discovers_index_in_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no index_path, the connection is opened from a .duckdb discovered under cwd."""
+    db_path = tmp_path / "nested" / "index.duckdb"
+    db_path.parent.mkdir()
+    _build_index(db_path, seq_rows=[_seq_row("hapA")])
+    monkeypatch.chdir(tmp_path)
+
+    conn = _get_index_connection(None)
+    try:
+        assert conn.execute("SELECT * FROM VERSION").fetchone() is not None
+    finally:
+        conn.close()
+
+
+def test_find_index_in_cwd_returns_none_when_absent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_find_index_in_cwd returns None (and _get_index_connection raises) when no index exists."""
+    monkeypatch.chdir(tmp_path)
+    assert _find_index_in_cwd() is None
+    with pytest.raises(RuntimeError, match="Unable to find a DuckDB index"):
+        _get_index_connection(None)


### PR DESCRIPTION
## Summary
Adds the missing coverage for the `remap_divref()` orchestration (only the Pydantic models were tested before) and fixes the two review nits in the tool, plus one hardening found while writing the tests.

## Tests (#68)
New `test_remap_divref_e2e.py` builds a minimal DuckDB index + a CALITAS TSV directly:
- `+` strand: full output-column assembly (`divref_*` originals, remapped `chromosome`/`coordinate_start`/`coordinate_end`, `genome_build`, `variants_involved`, per-pop `gnomAD_AF_*`/`estimated_*`) and the **`haplotype_filter` passthrough**;
- `-` strand: the `padded_len_adj` adjustment is subtracted from the start;
- error paths: missing required input column → `ValueError`; unknown haplotype id → `RuntimeError`; missing `VERSION`/`window_size`/`joint_pops_legend` table → `RuntimeError`;
- cwd index discovery (and connection close).

Also added translated `rm.start`/`rm.end` assertions to the deletion/insertion/multi-indel model tests. `remap_divref.py` coverage → 99%.

## Fixes
- **#74** — close the DuckDB connection via `contextlib.closing` so it isn't leaked on error (verified by a test that asserts the connection is closed after the call).
- **#75** — extract `_find_index_in_cwd` so discovery stops at the first match (the old `break` only exited the inner loop), and correct the docstring (it searches the **cwd** recursively, not "the directory containing this script").
- **Bonus (surfaced by #68 testing)** — the metadata-table guard only caught an *empty* table (which never happens for a real index); a *missing* table raised a raw `CatalogException`. It now raises the intended friendly `RuntimeError` naming the table.

## Verification
- `uv run --directory divref poe fix-and-check-all` — 190 passed, format/lint/mypy clean.

Closes #68
Closes #74
Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)