### PR TITLE
fix: constrain gnomad_version wildcard; verify Zenodo DuckDB download

### DIFF
--- a/workflows/compare_divref_gnomad.smk
+++ b/workflows/compare_divref_gnomad.smk
@@ -16,6 +16,9 @@ FREQUENCY_THRESHOLD: float = 0.005
 DIVREF_DUCKDB_URL: str = (
     "https://zenodo.org/records/14802613/files/" "DivRef-v1.1.haplotypes_gnomad_merge.index.duckdb"
 )
+# Zenodo-published md5 for the DuckDB above (record 14802613). Verified after download so a
+# truncated or corrupted fetch fails the rule instead of silently feeding a bad index downstream.
+DIVREF_DUCKDB_MD5: str = "6066d92f2d0269e4620602f4ded60b2b"
 GNOMAD_VERSIONS: list[str] = ["joint_41", "genomes_312", "hgdp_1kg_312"]
 
 # Maps filename wildcard → plot label used by compare_divref_gnomad.R
@@ -39,7 +42,11 @@ OUT_FILE_EXTS: list[str] = [
 ####################################################################################################
 
 
-ruleorder: compare_divref_gnomad > extract_gnomad_single_afs
+# Constrain gnomad_version to the known tokens so extract_gnomad_single_afs's
+# `{contig}.{gnomad_version}.tsv` cannot greedily match compare_divref_gnomad's
+# `{contig}.{gnomad_version}.divref_not_in_gnomad.tsv` (which previously forced a ruleorder).
+wildcard_constraints:
+    gnomad_version="|".join(GNOMAD_VERSIONS),
 
 
 rule all:
@@ -61,10 +68,21 @@ rule download_divref_index:
         f"logs/{COMPARISON_NAME}/download_divref_index.log",
     params:
         url=DIVREF_DUCKDB_URL,
+        expected_md5=DIVREF_DUCKDB_MD5,
     shell:
         """
         (
             wget --no-verbose -O {output.duckdb} {params.url}
+            # Verify against the Zenodo-published md5 (md5sum on Linux, md5 on macOS).
+            if command -v md5sum >/dev/null 2>&1; then
+                actual=$(md5sum "{output.duckdb}" | awk '{{print $1}}')
+            else
+                actual=$(md5 -q "{output.duckdb}")
+            fi
+            if [ "$actual" != "{params.expected_md5}" ]; then
+                echo "Checksum mismatch for {output.duckdb}: expected {params.expected_md5}, got $actual" >&2
+                exit 1
+            fi
         ) &> {log}
         """
 


### PR DESCRIPTION
## Summary
Two robustness fixes for the analysis-only `compare_divref_gnomad.smk` workflow.

## Changes
**#79 — drop the `ruleorder` band-aid.** `ruleorder: compare_divref_gnomad > extract_gnomad_single_afs` only existed because an unconstrained `{gnomad_version}` let `extract_gnomad_single_afs`'s `{contig}.{gnomad_version}.tsv` greedily match `compare_divref_gnomad`'s `{contig}.{gnomad_version}.divref_not_in_gnomad.tsv`. Replaced with a module-level `wildcard_constraints: gnomad_version="|".join(GNOMAD_VERSIONS)` so the two rules are unambiguous on their own.

**#80 — verify the download.** The ~3.6 GB DivRef 1.1 DuckDB was fetched from Zenodo with no integrity check. Now verified against the **Zenodo-published md5** (record 14802613 → `6066d92f2d0269e4620602f4ded60b2b`, obtained from the Zenodo API), failing the rule on mismatch. Portable check (`md5sum` on Linux, `md5 -q` on macOS).

## Verification
- `pixi run lint --check` (snakefmt) — clean.
- `pixi run snakemake -n -F` — full DAG builds (8 jobs: 3 `extract_gnomad_single_afs` + 3 `compare_divref_gnomad`) with **no `AmbiguousRuleException`**, confirming the constraint replaces the `ruleorder`.
- No Python changed.

## Heads-up (not addressed here)
While sourcing the checksum I noticed the local working copy at `data/analysis/input/DivRef-v1.1.haplotypes_gnomad_merge.index.duckdb` does **not** match the Zenodo artifact (local md5 `c0458a59…`, 4.13 GB vs Zenodo `6066d92f…`, 3.64 GB). With this checksum gate in place, a fresh run would re-download the canonical file — but you may want to confirm which copy your published analysis used.

Closes #79
Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)