### PR TITLE
style: apply Python house-rule conventions

### DIFF
--- a/divref/divref/hail.py
+++ b/divref/divref/hail.py
@@ -6,6 +6,7 @@ import pyspark
 
 
 def hail_init(
+    *,
     gcs_credentials_path: Path | None = None,
     spark_driver_memory_gb: int = 1,
     spark_executor_memory_gb: int = 1,

--- a/divref/divref/main.py
+++ b/divref/divref/main.py
@@ -1,7 +1,6 @@
 import logging
 import sys
-from typing import Callable
-from typing import List
+from collections.abc import Callable
 
 import defopt
 
@@ -16,7 +15,7 @@ from divref.tools.gnomad_hail_table_test_data import gnomad_hail_table_test_data
 from divref.tools.init_duckdb_index import init_duckdb_index
 from divref.tools.remap_divref import remap_divref
 
-_tools: List[Callable[..., None]] = [
+_tools: list[Callable[..., None]] = [
     append_contig_to_duckdb_index,
     compute_haplotypes,
     create_divref_fasta,

--- a/divref/divref/tools/extract_gnomad_afs.py
+++ b/divref/divref/tools/extract_gnomad_afs.py
@@ -44,11 +44,16 @@ def extract_gnomad_afs(
         spark_executor_memory_gb: Memory in GB to allocate to the Spark executor.
         use_s3: If `True`, initialize Hail with the S3A connector instead of the GCS
             connector. Set this when `in_gnomad_sites_table` is an `s3a://` URI.
+
+    Raises:
+        ValueError: If a requested population is absent from the gnomAD frequency metadata.
     """
     assert_path_is_writable(out_variant_annotation_table)
 
     hail_init(
-        gcs_credentials_path.expanduser() if gcs_credentials_path is not None else None,
+        gcs_credentials_path=(
+            gcs_credentials_path.expanduser() if gcs_credentials_path is not None else None
+        ),
         spark_driver_memory_gb=spark_driver_memory_gb,
         spark_executor_memory_gb=spark_executor_memory_gb,
         use_s3=use_s3,

--- a/divref/divref/tools/extract_gnomad_single_afs.py
+++ b/divref/divref/tools/extract_gnomad_single_afs.py
@@ -176,6 +176,10 @@ def extract_gnomad_single_afs(
             when `gnomad_cloud` is `GCS`; ignored otherwise.
         spark_driver_memory_gb: Memory in GB to allocate to the Spark driver.
         spark_executor_memory_gb: Memory in GB to allocate to the Spark executor.
+
+    Raises:
+        ValueError: If neither `out_sites_hail_table` nor `out_sites_tsv` is provided, or if a
+            requested population is absent from the gnomAD frequency metadata.
     """
     if out_sites_hail_table is None and out_sites_tsv is None:
         raise ValueError("At least one of out_sites_hail_table or out_sites_tsv must be provided")
@@ -185,7 +189,9 @@ def extract_gnomad_single_afs(
         assert_path_is_writable(out_sites_tsv)
 
     hail_init(
-        gcs_credentials_path.expanduser() if gcs_credentials_path is not None else None,
+        gcs_credentials_path=(
+            gcs_credentials_path.expanduser() if gcs_credentials_path is not None else None
+        ),
         spark_driver_memory_gb=spark_driver_memory_gb,
         spark_executor_memory_gb=spark_executor_memory_gb,
         use_s3=(gnomad_cloud is GnomadCloud.S3),

--- a/divref/divref/tools/extract_sample_metadata.py
+++ b/divref/divref/tools/extract_sample_metadata.py
@@ -38,7 +38,9 @@ def extract_sample_metadata(
     assert_path_is_writable(out_sample_metadata)
 
     hail_init(
-        gcs_credentials_path.expanduser() if gcs_credentials_path is not None else None,
+        gcs_credentials_path=(
+            gcs_credentials_path.expanduser() if gcs_credentials_path is not None else None
+        ),
         spark_driver_memory_gb=spark_driver_memory_gb,
         spark_executor_memory_gb=spark_executor_memory_gb,
         use_s3=use_s3,

--- a/divref/divref/tools/gnomad_hail_table_test_data.py
+++ b/divref/divref/tools/gnomad_hail_table_test_data.py
@@ -140,7 +140,7 @@ def gnomad_hail_table_test_data(
     assert_path_is_writable(out_samples_txt)
 
     hail_init(
-        gcs_credentials_path.expanduser(),
+        gcs_credentials_path=gcs_credentials_path.expanduser(),
         spark_driver_memory_gb=spark_driver_memory_gb,
         spark_executor_memory_gb=spark_executor_memory_gb,
     )


### PR DESCRIPTION
## Summary
Pure style/convention cleanup (#82) — no behavior change. Kept separate from the functional infra PR (#97) per the "never mix formatting and functional" rule.

## Changes
- **Keyword-only `hail_init`** — added the leading `*` and updated its four call sites (`extract_gnomad_afs`, `extract_gnomad_single_afs`, `extract_sample_metadata`, `gnomad_hail_table_test_data`) to pass `gcs_credentials_path` by keyword.
- **`Raises:` blocks** added to `extract_gnomad_afs` and `extract_gnomad_single_afs` (the two extract tools that actually raise `ValueError`).
- **Builtin generics in `main.py`** — `list[...]` and `collections.abc.Callable` instead of `typing.List` / `typing.Callable`.

## Scope notes (the original nit was slightly off)
- `gnomad_hail_table_test_data` **already** led with `*`, so only its call site changed.
- `extract_sample_metadata` raises nothing, so it gets no `Raises:` block (only its call site changed).

## Conflict-free with #97
This PR touches only `hail_init`'s **signature line** (the `*`); PR #97 touched `hail.py`'s **body + docstring**. Different hunks, so they merge cleanly in sequence regardless of order.

## Verification
- `uv run --directory divref poe fix-and-check-all` — 180 passed; ruff (check + format) and mypy clean.

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)