### PR TITLE
fix(scripts): count Venn overlap by distinct variant key

### DIFF
--- a/scripts/compare_divref_gnomad.R
+++ b/scripts/compare_divref_gnomad.R
@@ -100,13 +100,19 @@ divref_in_gnomad %>% write_tsv(paste0(opts$output_base, ".divref_in_gnomad.tsv")
 
 # Plot: Venn diagram of DivRef vs gnomAD variant overlap ----
 
-n_both <- nrow(divref_in_gnomad)
-n_divref_only <- nrow(divref_not_in_gnomad)
-n_gnomad_only <- nrow(gnomad) - n_both
+# Count by distinct variant key, not by joined-row count: a duplicate `variant` in the gnomAD
+# table would otherwise inflate the overlap and could push n_gnomad_only negative (which euler()
+# rejects). On clean inputs these equal the row counts. The joined frames above are still used for
+# the per-variant AF-difference plots.
+divref_keys <- unique(divref$variants)
+gnomad_keys <- unique(gnomad$variant)
+n_both <- length(intersect(divref_keys, gnomad_keys))
+n_divref_only <- length(setdiff(divref_keys, gnomad_keys))
+n_gnomad_only <- length(setdiff(gnomad_keys, divref_keys))
 
-log_info(nrow(divref_in_gnomad), " DivRef variants found in gnomAD")
-log_info(nrow(divref_not_in_gnomad), " DivRef variants not found in gnomAD")
-log_info(n_gnomad_only, "gnomAD variants not found in DivRef")
+log_info(n_both, " DivRef variants found in gnomAD")
+log_info(n_divref_only, " DivRef variants not found in gnomAD")
+log_info(n_gnomad_only, " gnomAD variants not found in DivRef")
 
 venn_counts <- c(n_divref_only, n_gnomad_only, n_both)
 names(venn_counts) <- c("DivRef 1.1", opts$gnomad_label, paste0("DivRef 1.1&", opts$gnomad_label))


### PR DESCRIPTION
## Summary
Analysis-script robustness fix (#88). `compare_divref_gnomad.R` computed `n_gnomad_only = nrow(gnomad) - nrow(divref_in_gnomad)`, where the subtrahend is a left-join row count. A duplicate `variant` key in the gnomAD TSV would inflate the overlap and could make `n_gnomad_only` negative, which `euler()` rejects.

Now all three Venn counts come from distinct variant-key set operations (`intersect` / `setdiff`), which is robust to duplicate keys and identical on clean inputs. The joined frames are still used for the per-variant AF-difference plots.

## Verification
- `pixi run --environment analysis Rscript -e 'parse(...)'` — parses cleanly.

## Note
#86 (the other item originally grouped here) is being closed as won't-do per discussion: the untracked sweep config is left as-is, and the population `enum` is skipped (an incomplete enum would risk rejecting valid runs without an authoritative gnomAD ancestry-code list). So this PR is #88 only.

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)