### PR TITLE
chore: retarget repository references to the fulcrumgenomics org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![CI](https://github.com/fg-labs/divref-wf/actions/workflows/python_package.yml/badge.svg?branch=main)](https://github.com/fg-labs/divref-wf/actions/workflows/python_package.yml?query=branch%3Amain)
-[![Python Versions](https://img.shields.io/badge/python-3.12_|_3.13-blue)](https://github.com/fg-labs/divref-wf)
+[![CI](https://github.com/fulcrumgenomics/divref-wf/actions/workflows/python_package.yml/badge.svg?branch=main)](https://github.com/fulcrumgenomics/divref-wf/actions/workflows/python_package.yml?query=branch%3Amain)
+[![Python Versions](https://img.shields.io/badge/python-3.12_|_3.13-blue)](https://github.com/fulcrumgenomics/divref-wf)
 [![MyPy Checked](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://docs.astral.sh/ruff/)

--- a/divref/README.md
+++ b/divref/README.md
@@ -1,8 +1,8 @@
 # divref
 
 
-[![CI](https://github.com/fg-labs/divref-wf/actions/workflows/python_package.yml/badge.svg?branch=main)](https://github.com/fg-labs/divref-wf/actions/workflows/python_package.yml?query=branch%3Amain)
-[![Python Versions](https://img.shields.io/badge/python-3.12_|_3.13-blue)](https://github.com/fg-labs/divref-wf)
+[![CI](https://github.com/fulcrumgenomics/divref-wf/actions/workflows/python_package.yml/badge.svg?branch=main)](https://github.com/fulcrumgenomics/divref-wf/actions/workflows/python_package.yml?query=branch%3Amain)
+[![Python Versions](https://img.shields.io/badge/python-3.12_|_3.13-blue)](https://github.com/fulcrumgenomics/divref-wf)
 [![MyPy Checked](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://docs.astral.sh/ruff/)

--- a/divref/pyproject.toml
+++ b/divref/pyproject.toml
@@ -35,9 +35,9 @@ classifiers     = [
 ]
 
 [project.urls]
-"homepage" = "https://github.com/fg-labs/divref-wf"
-"repository" = "https://github.com/fg-labs/divref-wf"
-"Bug Tracker" = "https://github.com/fg-labs/divref-wf/issues"
+"homepage" = "https://github.com/fulcrumgenomics/divref-wf"
+"repository" = "https://github.com/fulcrumgenomics/divref-wf"
+"Bug Tracker" = "https://github.com/fulcrumgenomics/divref-wf/issues"
 
 [project.scripts]
 divref = "divref.main:run"

--- a/docs/blog.md
+++ b/docs/blog.md
@@ -12,7 +12,7 @@ The [DivRef](https://zenodo.org/records/14802613) resource bundle developed by E
 
 The existing [DivRef generation workflow](https://github.com/e9genomics/human-diversity-reference) is a set of standalone Python scripts plus a Makefile, with some inputs hard-coded and others unrecorded.
 I wanted a bundle where I could trust the provenance of every haplotype and variant, and tune parameters for individual scientific applications.
-I [re-implemented](https://github.com/fg-labs/divref-wf) the existing workflow in Snakemake wrapping a Python toolkit, with a configuration schema, GCS or AWS Open Data ingestion, and per-chromosome parallelism so a full rebuild takes less than 20 hours on a laptop.
+I [re-implemented](https://github.com/fulcrumgenomics/divref-wf) the existing workflow in Snakemake wrapping a Python toolkit, with a configuration schema, GCS or AWS Open Data ingestion, and per-chromosome parallelism so a full rebuild takes less than 20 hours on a laptop.
 
 ### Headline improvements
 
@@ -279,5 +279,5 @@ gnomAD HGDP+1KG v3.1.2's PCA-based pop inference declines to assign a population
 
 ## Summary
 
-The new [divref-wf](https://github.com/fg-labs/divref-wf) produces a haplotype catalog whose frequencies are deterministic and reproducibly comparable across gnomAD releases.
+The new [divref-wf](https://github.com/fulcrumgenomics/divref-wf) produces a haplotype catalog whose frequencies are deterministic and reproducibly comparable across gnomAD releases.
 You can rebuild it quickly and painlessly with whatever AF threshold, population mix, or window size your application requires.

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,7 +1,7 @@
 [workspace]
 authors = ["Fulcrum Genomics"]
 channels = ["conda-forge", "bioconda"]
-name = "fg-labs-divref-wf"
+name = "fulcrumgenomics-divref-wf"
 platforms = ["osx-arm64", "osx-64", "linux-64"]
 version = "0.1.0"
 


### PR DESCRIPTION
The repository has been transferred from the `fg-labs` GitHub organization to `fulcrumgenomics`. GitHub redirects the old URLs indefinitely, but the in-tree references should name the canonical location rather than rely on redirects.

## Changes

| File | Change |
| --- | --- |
| `README.md` | CI badge + Python-versions badge URLs |
| `divref/README.md` | same two badge URLs |
| `divref/pyproject.toml` | `[project.urls]` homepage / repository / Bug Tracker |
| `docs/blog.md` | two prose links to the repository |
| `pixi.toml` | workspace `name`: `fg-labs-divref-wf` → `fulcrumgenomics-divref-wf` |

## Audit scope

Every tracked file was searched case-insensitively for `fg[-_ ]?labs`, along with a sweep of all `github.com` URLs, both lockfiles, and both Actions workflows. The five files above were the only hits.

Already correct and intentionally untouched: both `.github/workflows/*.yml` (no organization strings, only pinned action hashes), `LICENSE` (`Fulcrum Genomics LLC`), the `divref` package authors, `pixi.toml` authors, all Snakemake workflows, `scripts/`, and the `divref/` source tree.

## No lockfile churn

Neither `pixi.lock` nor `divref/uv.lock` records the workspace name or project URLs, so no re-lock was needed and the diff stays at 5 files / 10 lines.

## Verification

Both CI jobs were run locally with the same `--locked` flags CI uses:

- `uv run --directory divref --locked poe check-all` — exit 0, 206 tests passed, format/lint/mypy clean
- `pixi run --locked lint --check` — exit 0, snakefmt reports all 3 files unchanged
